### PR TITLE
Code Editor Highlighting

### DIFF
--- a/src/components/code_view.py
+++ b/src/components/code_view.py
@@ -1,86 +1,170 @@
 from customtkinter import *
 from tkinter import Event
-from src.lexer import Lexer,Token,Error
+from src.lexer import Lexer, Token, Error
+from enum import Enum
+
 
 class Linenums(CTkCanvas):
-   def __init__(self, master, text_widget: CTkTextbox, **kwargs):
-      super().__init__(master, **kwargs)
-      CTkCanvas.__init__(self, master=master, width=16, borderwidth=0,highlightthickness=0, bg='#1A1B26')
+    def __init__(self, master, text_widget: CTkTextbox, **kwargs):
+        super().__init__(master, **kwargs)
+        CTkCanvas.__init__(self, master=master, width=16, borderwidth=0, highlightthickness=0, bg='#1A1B26')
 
-      self.text_widget = text_widget
-      
-   def on_redraw(self, event: Event):
-      self.after(1, self.redraw, event)
+        self.text_widget = text_widget
 
-   def redraw(self, event: Event):
-      self.delete('all')
+    def on_redraw(self, event: Event):
+        self.after(1, self.redraw, event)
 
-      first_line = 1
-      last_line = int(event.widget.index(f"@0,{event.widget.winfo_height()}").split('.')[0])
+    def redraw(self, event: Event):
+        self.delete('all')
 
-      for lineno in range(first_line, last_line + 1):
-         dlineinfo: tuple[int, int, int, int, int] | None = event.widget.dlineinfo(f"{lineno}.0")
-         
-         if dlineinfo is None:
-            continue
+        first_line = 1
+        last_line = int(event.widget.index(f"@0,{event.widget.winfo_height()}").split('.')[0])
 
-         self.create_text(12, dlineinfo[1] + 10, text=f"{lineno}", anchor='center', fill='#333652', font=("Montserrat", 10))
+        for lineno in range(first_line, last_line + 1):
+            dlineinfo: tuple[int, int, int, int, int] | None = event.widget.dlineinfo(f"{lineno}.0")
+
+            if dlineinfo is None:
+                continue
+
+            self.create_text(12, dlineinfo[1] + 10, text=f"{lineno}", anchor='center', fill='#333652',
+                             font=("Montserrat", 10))
+
+
+class Tags(Enum):
+   """
+   A tag Enum class to keep track of the different tags
+   that the CodeEditor can use to format text.
+       name indicates the arbitrary tag name
+       options indicate the dict setting to be applied to the text when the tag is used
+
+   Sample tag initialization
+   <TAG_NAME> = (<name>,
+                 {<key>: <val>,
+                  <key>: <val>,
+                  ... }
+   """
+
+   def __init__(self, name: str, options: dict):
+      self._name = name
+      self._options = options
+
+   @property
+   def name(self):
+      return self._name
+
+   @property
+   def options(self):
+      return self._options
+
+   TOKEN_HIGHLIGHT = ("token_highlight",
+                      {"background": "#89ca78",
+                       "foreground": "#282c34"})
+
+   ERROR_HIGHLIGHT = ("error_highlight",
+                      {"background": "#971142"})
+
 
 class CodeEditor(CTkFrame):
-   def __init__(self, master, lexer: Lexer, **kwargs):
-      super().__init__(master, **kwargs)
+    def __init__(self, master, lexer: Lexer, **kwargs):
+        super().__init__(master, **kwargs)
 
-      self.lexer = lexer
-      self.tokens: list[Token] = []
-      self.errors: list[Error] = []
+        self.lexer = lexer
+        self.tokens: list[Token] = []
+        self.errors: list[Error] = []
 
-      self.grid_columnconfigure(0, weight=1)
-      self.grid_columnconfigure(1, weight=25)
-      self.grid_rowconfigure(0, weight=1)
+        self.grid_columnconfigure(0, weight=1)
+        self.grid_columnconfigure(1, weight=25)
+        self.grid_rowconfigure(0, weight=1)
 
-      self.text = CTkTextbox(master=self, corner_radius=0,fg_color='#1A1B26', text_color='#FFFFFF')
-      self.text.grid(row=0, column=1, sticky='nsew')
+        self.text = CTkTextbox(master=self, corner_radius=0, fg_color='#1A1B26', text_color='#FFFFFF')
+        self.text.grid(row=0, column=1, sticky='nsew')
 
-      self.line_nums = Linenums(master=self, text_widget=self.text)
-      self.line_nums.grid(row=0, column=0, sticky='nsew')
+        self.line_nums = Linenums(master=self, text_widget=self.text)
+        self.line_nums.grid(row=0, column=0, sticky='nsew')
 
-      self.text.bind("<Button-1>", lambda e: self.line_nums.on_redraw(e))
-      self.text.bind("<Tab>", lambda e: self.on_tab(e))
+        self.text.bind("<Button-1>", lambda e: self.line_nums.on_redraw(e))
+        self.text.bind("<Tab>", lambda e: self.on_tab(e))
 
-      self.text.bind("<Return>", lambda e: self.line_nums.on_redraw(e))
-      self.text.bind("<BackSpace>", lambda e: self.line_nums.on_redraw(e))
+        self.text.bind("<Return>", lambda e: self.line_nums.on_redraw(e))
+        self.text.bind("<BackSpace>", lambda e: self.line_nums.on_redraw(e))
 
-   def on_tab(self, e: Event):
-      e.widget.insert(INSERT, " " * 6)
-      return  'break'
+        # Initialize tags
+        for tag in Tags:
+            self.text.tag_config(tag.name, **tag.options)
 
-   def run_lexer(self):
-      source_code = [v + '\n' for v in self.text.get('1.0','end-1c').split('\n')]
-      print(source_code)
-      lx: Lexer = self.lexer(source_code)
+    def on_tab(self, e: Event):
+        e.widget.insert(INSERT, " " * 6)
+        return 'break'
 
-      self.tokens = lx.tokens
-      self.errors = lx.errors
+    def run_lexer(self):
+        source_code = [v + '\n' for v in self.text.get('1.0', 'end-1c').split('\n')]
+        print(source_code)
+        lx: Lexer = self.lexer(source_code)
+
+        self.tokens = lx.tokens
+        self.errors = lx.errors
+
+        Remote.code_editor_instance = self
+
+    def format(self, tag: str, start_pos: tuple[int, int], end_pos: tuple[int, int] = None):
+        """
+        Format a certain range of text in the textbox.
+            tag is a string that determines what formatting option will be applied.
+            start_pos indicates where to start applying
+            end_pos indicates where to stop applying
+            if start_pos and end_pos are the same, it will only format the single character in start_pos
+        """
+
+        # Set end_pos to None if it is equal to start_pos
+        end_pos = None if end_pos == start_pos else end_pos
+
+        # Set string indices
+        self.clear_format()
+        start_index = f"{start_pos[0]+1}.{start_pos[1]}"
+        end_index = None if end_pos is None else f"{end_pos[0]+1}.{end_pos[1]+1}"
+
+        # Format text in the index
+        self.text.tag_add(tag, start_index, end_index)
+
+    def clear_format(self, tags_to_clear: list[Tags] = None):
+        """
+        Clear all tags(formatting) in the textbox
+            tags_to_clear is an optional parameter to specify which tag/s to clear
+            by default, clears ALL tags
+        """
+
+        tags = tags_to_clear if tags_to_clear else Tags
+        for tag in tags:
+            self.text.tag_remove(tag.name, "1.0", "end")
+
 
 class CodeView(CTkTabview):
-   def __init__(self, master, **kwargs):
-      super().__init__(master, **kwargs)
-      # TODO: Remove on integ, filenames should be from uwu.py input
-      self.file_names = ['Untitled.uwu', 'Untitled(1).uwu']
-      self.code_editors: dict[str, CodeEditor] = {}
+    def __init__(self, master, **kwargs):
+        super().__init__(master, **kwargs)
+        self.file_names = ['Untitled.uwu', 'Untitled(1).uwu']
+        self.code_editors: dict[str, CodeEditor] = {}
 
-      for file in self.file_names:
-         tab = self.add(file)
-         tab.grid_columnconfigure((0,1), weight=1)
-         tab.grid_rowconfigure((0,1), weight=1)
+        for file in self.file_names:
+            tab = self.add(file)
+            tab.grid_columnconfigure((0, 1), weight=1)
+            tab.grid_rowconfigure((0, 1), weight=1)
 
-         code_editor = CodeEditor(master=tab, fg_color='transparent', lexer=Lexer)
-         code_editor.grid(row=0, column=0, rowspan=2, columnspan=2, sticky='nsew')
+            code_editor = CodeEditor(master=tab, fg_color='transparent', lexer=Lexer)
+            code_editor.grid(row=0, column=0, rowspan=2, columnspan=2, sticky='nsew')
 
-         self.code_editors[file] = code_editor
+            self.code_editors[file] = code_editor
 
-   def editor(self) -> CodeEditor:
-      tab = self.get()
-      code_editor: CodeEditor = self.code_editors[tab]
+    def editor(self) -> CodeEditor:
+        tab = self.get()
+        code_editor: CodeEditor = self.code_editors[tab]
 
-      return code_editor
+        return code_editor
+
+
+class Remote:
+    """
+   A way for other frames to easily interact with the current code editor instance.
+
+   This can be expanded to have other class instances in it.
+   """
+    code_editor_instance: CodeEditor = None

--- a/src/components/lexer_table.py
+++ b/src/components/lexer_table.py
@@ -1,32 +1,50 @@
 from customtkinter import *
 
 from src.lexer import Token
+from src.components.code_view import Remote, Tags
+
 
 class LexerTable(CTkFrame):
     def __init__(self, master, tokens: list[Token], **kwargs):
         super().__init__(master, **kwargs)
         self.tokens = tokens
         self.columns = (0, 1)
-        self.rows = tuple([i for i in range(len(self.tokens))]) if len(self.tokens) > 0 else (0,1,2,3,4)
+        self.rows = tuple([i for i in range(len(self.tokens))]) if len(self.tokens) > 0 else (0, 1, 2, 3, 4)
 
         self.grid_columnconfigure(self.columns, weight=1)
         self.grid_rowconfigure(self.rows, weight=1)
 
-        for i in range(len(self.tokens)):
-            self.lexeme = CTkLabel(master=self, text=self.tokens[i].lexeme, fg_color='transparent', text_color='#FFFFFF')
+        code_editor = Remote.code_editor_instance
+        self.lexemes_labels = []
+        self.token_labels = []
+        for i, token in enumerate(self.tokens):
+            lexeme_label = CTkLabel(master=self, text=token.lexeme, fg_color='transparent', text_color='#FFFFFF')
+            token_label = CTkLabel(master=self, text=token.token, fg_color='transparent', text_color='#FFFFFF')
 
-            self.token = CTkLabel(master=self, text=self.tokens[i].token, fg_color='transparent', text_color='#FFFFFF')
+            lexeme_label.grid(row=i, column=0, sticky='ew')
+            token_label.grid(row=i, column=1, sticky='ew')
 
-            self.lexeme.grid(row=i, column=0, sticky='ew')
-            self.token.grid(row=i, column=1, sticky='ew')
+            # Bind callbacks for token highlighting
+            lexeme_label.bind("<Enter>", lambda ev, t=token: code_editor.format(Tags.TOKEN_HIGHLIGHT.name,
+                                                                                tuple(t.position),
+                                                                                tuple(t.end_position)))
+            token_label.bind("<Enter>", lambda ev, t=token: code_editor.format(Tags.TOKEN_HIGHLIGHT.name,
+                                                                               tuple(t.position),
+                                                                               tuple(t.end_position)))
+            lexeme_label.bind("<Leave>", lambda ev: code_editor.clear_format())
+            token_label.bind("<Leave>", lambda ev: code_editor.clear_format())
+
+            self.lexemes_labels.append(lexeme_label)
+            self.token_labels.append(token_label)
+
 
 class LexerCanvas(CTkCanvas):
     def __init__(self, master, **kwargs):
         super().__init__(master, **kwargs)
-        CTkCanvas.__init__(self, master=master, width=16, borderwidth=0,highlightthickness=0, bg='#1A1B26')
+        CTkCanvas.__init__(self, master=master, width=16, borderwidth=0, highlightthickness=0, bg='#1A1B26')
 
-        self.grid_columnconfigure((0,1), weight=1)
-        self.grid_rowconfigure((0,1), weight=1)
+        self.grid_columnconfigure((0, 1), weight=1)
+        self.grid_rowconfigure((0, 1), weight=1)
 
         self.render_table()
 

--- a/src/components/lexer_table.py
+++ b/src/components/lexer_table.py
@@ -1,7 +1,7 @@
 from customtkinter import *
 
 from src.lexer import Token
-from src.components.code_view import Remote, Tags
+from .code_view import Remote, Tags
 
 
 class LexerTable(CTkFrame):


### PR DESCRIPTION
(Note: Mukang madaming changes but I think Github's just having a hard time telling what was actually added idk T.T)

## Additions
### `Tags` Class
- enum class that stores tags
- tags are used by Tkinter to apply formatting to text in TextBoxes
- tags have a `name` which can be set arbitrarily (used by Tkinter to differentiate between tags)
- tags have a `options` parameter where you can put in formatting arguments for the tag (i.e background, foreground, etc.)

### `Remote` Class
- a class that other modules can interface with to get a reference to the current CodeEditor instance
- just import Remote from code_view.py to get the instance

### `self.format` Method in `CodeEditor` Class
- formats a range of text in the current CodeEditor TextBox
- takes in a `tag` parameter to know what formatting option to apply
- takes in `start_pos` and `end_pos` parameters to know where to apply formatting option
- `end-pos` is optional, thus only highlighting only 1 character located in `start_pos`

### `self.clear_format` Method in `CodeEditor` Class
- clears all formatting of all text by default
- can accept optional list of tags to only clear the formatting of those tags

### Binded hover callbacks to lexeme and token labels in `LexerTable`
- `<Enter>` callback calls `CodeEditor.format()` and passes the position of the relevant token being hovered over
- `<Leave>` callback calls `CodeEditor.clear_format()`

## Changes
### Changed how the `LexerTable` is initialized
- I noticed that the different lexemes and token `Labels` are stored in one `self` attribute
- Doesn't affect functionality, but made it so there's only two `self.lexemes` and `self.tokens` attributes
- These are lists where the created `Labels` are appended to