### PR TITLE
More Highlighting Stuff

### DIFF
--- a/src/components/code_view.py
+++ b/src/components/code_view.py
@@ -126,6 +126,24 @@ class CodeEditor(CTkFrame):
         # Format text in the index
         self.text.tag_add(tag, start_index, end_index)
 
+    def format_multiple(self, tag: str, ranges: list[(tuple[int, int], tuple[int, int] | None)]):
+        """
+        Formats text in the given list of positions
+            tag is a string that determines what formatting option will be applied.
+            positions is a list of start_pos and end_pos(optional) for tokens to be formatted
+        """
+
+        for start_pos, end_pos in ranges:
+            # Set end_pos to None if it is equal to start_pos
+            end_pos = None if end_pos == start_pos else end_pos
+
+            # Set string indices
+            start_index = f"{start_pos[0] + 1}.{start_pos[1]}"
+            end_index = None if end_pos is None else f"{end_pos[0] + 1}.{end_pos[1] + 1}"
+
+            # Format text in the index
+            self.text.tag_add(tag, start_index, end_index)
+
     def clear_format(self, tags_to_clear: list[Tags] = None):
         """
         Clear all tags(formatting) in the textbox

--- a/src/components/lexer_table.py
+++ b/src/components/lexer_table.py
@@ -14,7 +14,7 @@ class LexerTable(CTkFrame):
         self.grid_columnconfigure(self.columns, weight=1)
         self.grid_rowconfigure(self.rows, weight=1)
 
-        code_editor = Remote.code_editor_instance
+        self.code_editor = Remote.code_editor_instance
         self.lexemes_labels = []
         self.token_labels = []
         for i, token in enumerate(self.tokens):
@@ -25,17 +25,22 @@ class LexerTable(CTkFrame):
             token_label.grid(row=i, column=1, sticky='ew')
 
             # Bind callbacks for token highlighting
-            lexeme_label.bind("<Enter>", lambda ev, t=token: code_editor.format(Tags.TOKEN_HIGHLIGHT.name,
-                                                                                tuple(t.position),
-                                                                                tuple(t.end_position)))
-            token_label.bind("<Enter>", lambda ev, t=token: code_editor.format(Tags.TOKEN_HIGHLIGHT.name,
-                                                                               tuple(t.position),
-                                                                               tuple(t.end_position)))
-            lexeme_label.bind("<Leave>", lambda ev: code_editor.clear_format())
-            token_label.bind("<Leave>", lambda ev: code_editor.clear_format())
+            lexeme_label.bind("<Enter>", lambda ev, t=token: self.on_hover(t))
+            token_label.bind("<Enter>", lambda ev, t=token: self.on_hover(t))
+            lexeme_label.bind("<Button-1>", lambda ev, t=token: self.on_click(t))
+            token_label.bind("<Button-1>", lambda ev, t=token: self.on_click(t))
+            lexeme_label.bind("<Leave>", lambda ev: self.code_editor.clear_format())
+            token_label.bind("<Leave>", lambda ev: self.code_editor.clear_format())
 
             self.lexemes_labels.append(lexeme_label)
             self.token_labels.append(token_label)
+
+    def on_hover(self, token):
+        self.code_editor.format(Tags.TOKEN_HIGHLIGHT.name, tuple(token.position), tuple(token.end_position))
+
+    def on_click(self, token):
+        positions = [(_t.position, _t.end_position) for _t in self.tokens if str(_t.token) == str(token.token)]
+        self.code_editor.format_multiple(Tags.TOKEN_HIGHLIGHT.name, positions)
 
 
 class LexerCanvas(CTkCanvas):

--- a/src/components/logs_table.py
+++ b/src/components/logs_table.py
@@ -1,5 +1,6 @@
 from customtkinter import *
-from src.lexer import Error
+from src.lexer.lexer import Error, DelimError
+from src.components.code_view import Tags, Remote
 
 class LogsTable(CTkFrame):
     def __init__(self, master, logs: list[Error], **kwargs):
@@ -11,15 +12,26 @@ class LogsTable(CTkFrame):
         self.grid_columnconfigure((0,1,2,3,4,5,6,7,8,9,10), weight=1)
         self.grid_rowconfigure(self.rows, weight=1)
 
+        self.code_editor = Remote.code_editor_instance
+        self.line_labels = []
+        self.log_message_labels = []
         for row in range(len(self.logs)):
             # TODO: Change render on Integ
-            line, _ = self.logs[row].position
-            self.line_label = CTkLabel(master=self, text=line+1, fg_color='transparent', text_color='#FFFFFF', anchor='n')
+            start_pos = line, col = self.logs[row].position
+            end_pos = None if isinstance(self.logs[row], DelimError) else self.logs[row].end_position
+            line_label = CTkLabel(master=self, text=line + 1, fg_color='transparent', text_color='#FFFFFF', anchor='n')
 
-            self.log_message_label = CTkLabel(master=self, text=self.logs[row], fg_color='transparent', text_color='#ff5349', anchor='nw')
+            log_message_label = CTkLabel(master=self, text=self.logs[row], fg_color='transparent', text_color='#ff5349',
+                                         anchor='nw')
 
-            self.line_label.grid(row=row, column=0, sticky='nsew', padx=32, pady=8)
-            self.log_message_label.grid(row=row, column=1, sticky='nsew', columnspan=9, pady=8)
+            # Bind callbacks
+            log_message_label.bind("<Enter>", lambda ev, sp=start_pos, ep=end_pos: self.code_editor.format(
+                Tags.ERROR_HIGHLIGHT.name, sp, ep
+            ))
+            log_message_label.bind("<Leave>", lambda ev: self.code_editor.clear_format())
+
+            line_label.grid(row=row, column=0, sticky='nsew', padx=32, pady=8)
+            log_message_label.grid(row=row, column=1, sticky='nsew', columnspan=9, pady=8)
 
 class LogsCanvas(CTkCanvas):
     def __init__(self, master, **kwargs):


### PR DESCRIPTION
## Main Changes
- Error Highlighting (hover)
- Highlight all lexemes of a given token type (click)
- New method `format_multiple` (accepts list of `start_pos` and `end_pos`)

## Extra
- Refactored code for callbacks for token_highlighting
- Fixed some imports (typehinting lang affected neto mostly so no functional changes nmn)
- Refactored how error labels get initialized, made it similar to how the token table is initialized