### PR TITLE
Feat/rewrite parser

### DIFF
--- a/constants/constants.py
+++ b/constants/constants.py
@@ -29,7 +29,7 @@ DELIMS = {
     'mainuwu': {'-', ' '},
     'int_float': {',', ' ', *ATOMS['general_operator'], ')', '}', ']', '~', '!', r'&', '|', '>', '<', '='},
     'string': {' ', ')', ',', '&', '}', '[', ']', '~', '!', '='},
-    'assign_delim': {*ATOMS['alpha'], *ATOMS['number'], '{', ' ', '-' '('},
+    'assign_delim': {*ATOMS['alpha'], *ATOMS['number'], '{', ' ', '-', '('},
     'operator_delim': {*ATOMS['alpha'], *ATOMS['number'], ' ', '-', '('},
     'logical_delim': {'"', *ATOMS['alpha'], *ATOMS['number'], ' ', '-', '('},
     'string_parts': {'"', *ATOMS['alpha'], *ATOMS['number'], ' ', '-', '(', '|'},

--- a/constants/constants.py
+++ b/constants/constants.py
@@ -20,7 +20,7 @@ ATOMS = {
 
 DELIMS = {
     'end': {'~', ' '},
-    'data_type': {',', '(', ')', ' ', '~', '=', '-'},
+    'data_type': {'[', ',', '(', ')', ' ', '~', '=', '-'},
     'dono': {',', '(', ')', ' ', '='},
     'cwass': {',', '(', ')', ' ', '='},
     'bool': {',', ' ', '}', ')', '~'},
@@ -38,9 +38,9 @@ DELIMS = {
     'open_parenthesis': {*ATOMS['number'], *ATOMS['alpha'], ' ', '-', '\n', '>', '(', ')', '"'},
     'id': {' ', '~', ',', '(', ')', '[', ']', '}', *ATOMS['general_operator'], '!', r'&', '|', '.'},
     'close_parenthesis': {' ', *ATOMS['general_operator'], '!', '&', '|', '\n', '~', '>', '.', ',', ')', '(', '[', ']', '}'},
-    'open_bracket': {*ATOMS['number'], '-', *ATOMS['alpha'], '(', ' '},
+    'open_bracket': {']', *ATOMS['number'], '-', *ATOMS['alpha'], '(', ' '},
     'double_open_bracket': {' ', '\n', *ATOMS['alpha'], '>'},
-    'close_bracket': {' ', '~', ',', ')', '[', ']', '}', *ATOMS['general_operator'], '!', r'&', '|', '.',},
+    'close_bracket': {'[', ' ', '~', ',', ')', '[', ']', '}', *ATOMS['general_operator'], '!', r'&', '|', '.',},
     'double_close_bracket': {' ', '\n', *ATOMS['alpha'], '>'},
     'unary': {'~', ')', *ATOMS['general_operator'], '!', ' '},
     'concat': {' ', '"', *ATOMS['alpha']},

--- a/src/lexer/__init__.py
+++ b/src/lexer/__init__.py
@@ -1,8 +1,9 @@
 # Treat lexer as a package
-from .lexer import Lexer
+from .lexer import Lexer, print_lex
 from .token import Token
 from .error_handler import Error
 
 Lexer
 Token
 Error
+print_lex

--- a/src/lexer/__main__.py
+++ b/src/lexer/__main__.py
@@ -4,7 +4,8 @@ from .lexer import *
 if __name__ == "__main__":
     # temporary test source code
     source_code = [
-        '-5, -4, 5--1 ',
+        '-5, "start| -4, 5--1~',
+        '"tokino \'|-5, -4, 5--1|\' sora"~',
         # 'aqua shion ojou1',
         # 'fwunc manji-Manji() ',
         # 'manji+manji() ',

--- a/src/lexer/__main__.py
+++ b/src/lexer/__main__.py
@@ -4,7 +4,7 @@ from .lexer import *
 if __name__ == "__main__":
     # temporary test source code
     source_code = [
-        '"|1- -5,',
+        '"|1      - -        5,',
         # '-5, "start| -4, 5--1~',
         # '"tokino \'| -5, -4, -5----1|\' sora"~',
         # 'aqua shion ojou1',

--- a/src/lexer/__main__.py
+++ b/src/lexer/__main__.py
@@ -4,7 +4,8 @@ from .lexer import *
 if __name__ == "__main__":
     # temporary test source code
     source_code = [
-        'aqua shion ojou1',
+        '-5, -4, 5--1 ',
+        # 'aqua shion ojou1',
         # 'fwunc manji-Manji() ',
         # 'manji+manji() ',
         # 'fwunc manji+Class() ',

--- a/src/lexer/__main__.py
+++ b/src/lexer/__main__.py
@@ -4,8 +4,9 @@ from .lexer import *
 if __name__ == "__main__":
     # temporary test source code
     source_code = [
-        '-5, "start| -4, 5--1~',
-        '"tokino \'|-5, -4, 5--1|\' sora"~',
+        '"|1- -5,',
+        # '-5, "start| -4, 5--1~',
+        # '"tokino \'| -5, -4, -5----1|\' sora"~',
         # 'aqua shion ojou1',
         # 'fwunc manji-Manji() ',
         # 'manji+manji() ',

--- a/src/lexer/lexer.py
+++ b/src/lexer/lexer.py
@@ -426,7 +426,7 @@ class Lexer():
         for error in self.errors:
             print(error)
 
-def print_lex(source_code: list[str]):
+def print_lex(source_code: list[str]) -> Lexer:
     print('\nsample text file')
     print("_"*20)
     for i, line in enumerate(source_code):
@@ -446,3 +446,4 @@ def print_lex(source_code: list[str]):
         print(f"{f'{token.position} - {token.end_position}':^23}", end=border)
         print()
     print("","_"*63)
+    return x

--- a/src/lexer/lexer.py
+++ b/src/lexer/lexer.py
@@ -470,11 +470,15 @@ class Lexer():
             print(error)
 
 def print_lex(source_code: list[str]) -> Lexer:
+    max_digit_length = len(str(len(source_code)))
+    max_width = max(len(line) for line in source_code) + max_digit_length + 3
+
     print('\nsample text file')
-    print("_"*20)
+    print("-"*max_width)
     for i, line in enumerate(source_code):
+        line = line if line != '\n' else ''
         print(f"{i+1} | {line}")
-    print("_"*20)
+    print("-"*max_width)
     print('end of file\n')
     x = Lexer(source_code)
     x.print_error_logs()

--- a/src/lexer/lexer.py
+++ b/src/lexer/lexer.py
@@ -488,7 +488,8 @@ def print_lex(source_code: list[str]) -> Lexer:
     border = "|"
     for token in x.tokens:
         print(border, end='')
-        print(f"{token.lexeme:^18}", end=border)
+        lexeme = token.lexeme if token.lexeme not in ['\n', '\t'] else ' '
+        print(f"{lexeme:^18}", end=border)
         print(f"{token.token:^20}", end=border)
         print(f"{f'{token.position} - {token.end_position}':^23}", end=border)
         print()

--- a/src/lexer/lexer.py
+++ b/src/lexer/lexer.py
@@ -14,6 +14,7 @@ class Lexer():
         UniqueTokenType.clear()
 
         self._position = [0,0]
+        self._at_EOF = False
         self._current_char = self._lines[self._position[0]][self._position[1]]
 
         self._nest_level = 0
@@ -30,189 +31,204 @@ class Lexer():
     @property
     def errors(self):
         return self._logs
-    
+
+    def advance(self):
+       self._at_EOF, self._current_char = advance_cursor(self.context)
+
+    # methods that interact with outside modules
     @property
     def context(self):
         'to be passed to outside modules'
         return self._lines, self._position, self._current_char, self._tokens, self._logs
+    def peek_reserved(self, reserved: str, token_type: TokenType) -> bool:
+        cursor_advanced, self._at_EOF, self._current_char = peek.reserved(reserved, token_type, self.context)
+        return cursor_advanced
+    def peek_comments(self, multiline: bool = False) -> bool:
+        cursor_advanced, self._at_EOF, self._current_char = peek.comments(self.context, multiline=multiline)
+        return cursor_advanced
+    def peek_ident(self, cwass: bool = False) -> bool:
+        self._at_EOF, self._current_char  = peek.identifier(self.context, cwass=cwass)
+    def peek_int_float(self):
+        self._at_EOF, self._current_char = peek.int_float(self.context)
+    def peek_string(self):
+        self._at_EOF, self._current_char = peek.string(self.context)
 
     def _get_tokens(self):
-        is_end_of_file = False
         cursor_advanced = False
         valid_starting_chars = {*ATOMS['alphanum'], *ATOMS['general_operator'],
                                 '|', '!', '&', '{', '}', '[', ']', '(', ')', ',', '.', '~', '"'}
         
-        while not is_end_of_file:
+        while not self._at_EOF:
             if self._current_char in ['\n', ' ', '\t']:
                 self._tokens.append(Token(self._current_char, TokenType.WHITESPACE, tuple(self._position), tuple(self._position)))
-                is_end_of_file, self._current_char = advance_cursor(self.context)
-                if is_end_of_file:
+                self.advance()
+                if self._at_EOF:
                     break
                 continue
 
             if self._current_char not in valid_starting_chars:
                 self._logs.append(GenericError(Error.UNEXPECTED_SYMBOL, tuple(self._position)))
-                is_end_of_file, self._current_char = advance_cursor(self.context)
-                if is_end_of_file:
+                self.advance()
+                if self._at_EOF:
                     break
                 continue
 
             if self._current_char == 'b':
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('bweak', TokenType.BWEAK, self.context)
+                cursor_advanced = self.peek_reserved('bweak', TokenType.BWEAK)
                 if cursor_advanced:
                     continue
 
             if self._current_char == 'c':
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('chan', TokenType.CHAN, self.context)
+                cursor_advanced = self.peek_reserved('chan', TokenType.CHAN)
                 if cursor_advanced:
                     continue
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('cap', TokenType.CAP, self.context)
+                cursor_advanced = self.peek_reserved('cap', TokenType.CAP)
                 if cursor_advanced:
                     continue
 
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('cwass', TokenType.CWASS, self.context)
+                cursor_advanced = self.peek_reserved('cwass', TokenType.CWASS)
                 if cursor_advanced:
                     continue
             
             if self._current_char == 'd':
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('dono', TokenType.DONO, self.context)
+                cursor_advanced = self.peek_reserved('dono', TokenType.DONO)
                 if cursor_advanced:
                     continue
 
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('do whiwe', TokenType.DO_WHIWE, self.context)
+                cursor_advanced = self.peek_reserved('do whiwe', TokenType.DO_WHIWE)
                 if cursor_advanced:
                     continue
                 
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('donee~', TokenType.DONE, self.context)
+                cursor_advanced = self.peek_reserved('donee~', TokenType.DONE)
                 if cursor_advanced:
                     continue
             
             if self._current_char == 'e':
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('ewse iwf', TokenType.EWSE_IWF, self.context)
+                cursor_advanced = self.peek_reserved('ewse iwf', TokenType.EWSE_IWF)
                 if cursor_advanced:
                     continue
 
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('ewse', TokenType.EWSE, self.context)
+                cursor_advanced = self.peek_reserved('ewse', TokenType.EWSE)
                 if cursor_advanced:
                     continue
                 
             if self._current_char == 'f':
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved("fwunc", TokenType.FWUNC, self.context)
+                cursor_advanced = self.peek_reserved("fwunc", TokenType.FWUNC)
                 if cursor_advanced:
                     continue
 
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('fax', TokenType.FAX, self.context)
+                cursor_advanced = self.peek_reserved('fax', TokenType.FAX)
                 if cursor_advanced:
                     continue
 
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('fow', TokenType.FOW, self.context)
+                cursor_advanced = self.peek_reserved('fow', TokenType.FOW)
                 if cursor_advanced:
                     continue
         
             if self._current_char == 'g':
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('gwobaw', TokenType.GWOBAW, self.context)
+                cursor_advanced = self.peek_reserved('gwobaw', TokenType.GWOBAW)
                 if cursor_advanced:
                     continue
             
             if self._current_char == 'i':
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('iwf', TokenType.IWF, self.context)
+                cursor_advanced = self.peek_reserved('iwf', TokenType.IWF)
                 if cursor_advanced:
                     continue
 
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('inpwt', TokenType.INPWT, self.context)
+                cursor_advanced = self.peek_reserved('inpwt', TokenType.INPWT)
                 if cursor_advanced:
                     continue
             
             if self._current_char == 'k':
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('kun', TokenType.KUN, self.context)
+                cursor_advanced = self.peek_reserved('kun', TokenType.KUN)
                 if cursor_advanced:
                     continue
             
             if self._current_char == 'm':
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('mainuwu', TokenType.MAINUWU, self.context)
+                cursor_advanced = self.peek_reserved('mainuwu', TokenType.MAINUWU)
                 if cursor_advanced:
                     continue
 
             if self._current_char == 'n':
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('nuww', TokenType.NUWW, self.context)
+                cursor_advanced = self.peek_reserved('nuww', TokenType.NUWW)
                 if cursor_advanced:
                     continue
             
             if self._current_char == 'p':
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('pwint', TokenType.PWINT, self.context)
+                cursor_advanced = self.peek_reserved('pwint', TokenType.PWINT)
                 if cursor_advanced:
                     continue
 
             if self._current_char == 's':
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('san', TokenType.SAN, self.context)
+                cursor_advanced = self.peek_reserved('san', TokenType.SAN)
                 if cursor_advanced:
                     continue
 
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('sama', TokenType.SAMA, self.context)
+                cursor_advanced = self.peek_reserved('sama', TokenType.SAMA)
                 if cursor_advanced:
                     continue
 
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('senpai', TokenType.SENPAI, self.context)
+                cursor_advanced = self.peek_reserved('senpai', TokenType.SENPAI)
                 if cursor_advanced:
                     continue
 
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('staart!', TokenType.START, self.context)
+                cursor_advanced = self.peek_reserved('staart!', TokenType.START)
                 if cursor_advanced:
                     continue
 
             if self._current_char == 'w':
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('whiwe', TokenType.WHIWE, self.context)
+                cursor_advanced = self.peek_reserved('whiwe', TokenType.WHIWE)
                 if cursor_advanced:
                     continue
 
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('wetuwn', TokenType.WETUWN, self.context)
+                cursor_advanced = self.peek_reserved('wetuwn', TokenType.WETUWN)
                 if cursor_advanced:
                     continue
             
             # Literals check
             # can be identifiers or function names
             if self._current_char in ATOMS['alpha_small']:
-                is_end_of_file, self._current_char = peek.identifier(self.context)
-                if is_end_of_file:
+                self.peek_ident()
+                if self._at_EOF:
                     break
                 continue
 
             # class names
             if self._current_char in ATOMS['alpha_big']:
-                is_end_of_file, self._current_char  = peek.identifier(self.context, cwass=True)
-                if is_end_of_file:
+                self.peek_ident(cwass=True)
+                if self._at_EOF:
                     break
                 continue
             
             if self._current_char in ATOMS['number']:
-                is_end_of_file, self._current_char = peek.int_float(self.context)
-                if is_end_of_file:
+                self.peek_int_float()
+                if self._at_EOF:
                     break
                 continue
             
             # string literals
             if self._current_char in ['|', '"']:
-                is_end_of_file, self._current_char = peek.string(self.context)
-                if is_end_of_file:
+                self.peek_string()
+                if self._at_EOF:
                     break
                 continue
 
             # Symbol Checks
             if self._current_char == '=':
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('==', TokenType.EQUALITY_OPERATOR, self.context)
+                cursor_advanced = self.peek_reserved('==', TokenType.EQUALITY_OPERATOR)
                 if cursor_advanced:
                     continue
 
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('=', TokenType.ASSIGNMENT_OPERATOR, self.context)
+                cursor_advanced = self.peek_reserved('=', TokenType.ASSIGNMENT_OPERATOR)
                 if cursor_advanced:
                     continue
 
             if self._current_char == '+':
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('++', TokenType.INCREMENT_OPERATOR, self.context)
+                cursor_advanced = self.peek_reserved('++', TokenType.INCREMENT_OPERATOR)
                 if cursor_advanced:
                     continue
 
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('+', TokenType.ADDITION_SIGN, self.context)
+                cursor_advanced = self.peek_reserved('+', TokenType.ADDITION_SIGN)
                 if cursor_advanced:
                     continue
 
@@ -224,7 +240,7 @@ class Lexer():
                 if len(after_slice) < 1:
                     line, col = self._position
                     self._logs.append(DelimError(TokenType.DASH, (line, col + 1), '-', '\n'))
-                    is_end_of_file, self._current_char = advance_cursor(self.context)
+                    self.advance()
                     continue
 
                 # Check if - is negative
@@ -237,9 +253,9 @@ class Lexer():
                 line_copy = self._lines[line]
                 if line_copy.lstrip()[0] == '-' or operator_before:
                     if after_slice[0] in ATOMS["number"]:
-                        is_end_of_file, self._current_char = advance_cursor(self.context)
-                        is_end_of_file, self._current_char = peek.int_float(self.context, negative=True)
-                        if is_end_of_file:
+                        self.advance()
+                        self.peek_int_float()
+                        if self._at_EOF:
                             break
                         continue
 
@@ -252,128 +268,128 @@ class Lexer():
                                 starting_position = tuple(self._position)
                                 ending_position = tuple([self._position[0], self._position[1]+1])
                                 self._tokens.append(Token('--', TokenType.DECREMENT_OPERATOR, starting_position, ending_position))
-                                is_end_of_file, self._current_char = advance_cursor(self.context, 2)
+                                self.advance()
                                 continue
                     starting_position = ending_position = tuple(self._position)
                     self._tokens.append(Token('-', TokenType.DASH, starting_position, ending_position))
-                    is_end_of_file, self._current_char = advance_cursor(self.context)
+                    self.advance()
                     continue
 
             if self._current_char == '!':
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('!=', TokenType.INEQUALITY_OPERATOR, self.context)
+                cursor_advanced = self.peek_reserved('!=', TokenType.INEQUALITY_OPERATOR)
                 if cursor_advanced:
                     continue
 
                 self._logs.append(GenericError(Error.UNEXPECTED_SYMBOL, tuple(self._position),
                                                context=f"Symbol {self._current_char} is invalid. Did you mean '!='?"))
-                is_end_of_file, self._current_char = advance_cursor(self.context)
+                self.advance()
                 continue
 
             if self._current_char == '>':
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('>=', TokenType.GREATER_THAN_OR_EQUAL_SIGN, self.context)
+                cursor_advanced = self.peek_reserved('>=', TokenType.GREATER_THAN_OR_EQUAL_SIGN)
                 if cursor_advanced:
                     continue
 
-                cursor_advanced, is_end_of_file, self._current_char = peek.comments(self.context)
+                cursor_advanced = self.peek_comments()
                 if cursor_advanced:
                     continue
 
-                cursor_advanced, is_end_of_file, self._current_char = peek.comments(self.context, multiline=True)
+                cursor_advanced = self.peek_comments(multiline=True)
                 if cursor_advanced:
                     continue
 
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('>', TokenType.GREATER_THAN_SIGN, self.context)
+                cursor_advanced = self.peek_reserved('>', TokenType.GREATER_THAN_SIGN)
                 if cursor_advanced:
                     continue
 
             if self._current_char == '<':
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('<=', TokenType.LESS_THAN_OR_EQUAL_SIGN, self.context)
+                cursor_advanced = self.peek_reserved('<=', TokenType.LESS_THAN_OR_EQUAL_SIGN)
                 if cursor_advanced:
                     continue
 
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('<', TokenType.LESS_THAN_SIGN, self.context)
+                cursor_advanced = self.peek_reserved('<', TokenType.LESS_THAN_SIGN)
                 if cursor_advanced:
                     continue
 
             if self._current_char == '*':
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('*', TokenType.MULTIPLICATION_SIGN, self.context)
+                cursor_advanced = self.peek_reserved('*', TokenType.MULTIPLICATION_SIGN)
                 if cursor_advanced:
                     continue
 
             if self._current_char == '/':
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('/', TokenType.DIVISION_SIGN, self.context)
+                cursor_advanced = self.peek_reserved('/', TokenType.DIVISION_SIGN)
                 if cursor_advanced:
                     continue
 
             if self._current_char == '%':
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('%', TokenType.MODULO_SIGN, self.context)
+                cursor_advanced = self.peek_reserved('%', TokenType.MODULO_SIGN)
                 if cursor_advanced:
                     continue
 
             if self._current_char == "|":
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('||', TokenType.OR_OPERATOR, self.context)
+                cursor_advanced = self.peek_reserved('||', TokenType.OR_OPERATOR)
                 if cursor_advanced:
                     continue
 
             if self._current_char == "&":
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('&&', TokenType.AND_OPERATOR, self.context)
+                cursor_advanced = self.peek_reserved('&&', TokenType.AND_OPERATOR)
                 if cursor_advanced:
                     continue
 
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('&', TokenType.CONCATENATION_OPERATOR, self.context)
+                cursor_advanced = self.peek_reserved('&', TokenType.CONCATENATION_OPERATOR)
                 if cursor_advanced:
                     continue
 
             if self._current_char == "{":
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('{', TokenType.OPEN_BRACE, self.context)
+                cursor_advanced = self.peek_reserved('{', TokenType.OPEN_BRACE)
                 if cursor_advanced:
                     continue
 
             if self._current_char == "}":
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('}', TokenType.CLOSE_BRACE, self.context)
+                cursor_advanced = self.peek_reserved('}', TokenType.CLOSE_BRACE)
                 if cursor_advanced:
                     continue
 
             if self._current_char == "(":
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('(', TokenType.OPEN_PAREN, self.context)
+                cursor_advanced = self.peek_reserved('(', TokenType.OPEN_PAREN)
                 if cursor_advanced:
                     continue
 
             if self._current_char == ")":
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved(')', TokenType.CLOSE_PAREN, self.context)
+                cursor_advanced = self.peek_reserved(')', TokenType.CLOSE_PAREN)
                 if cursor_advanced:
                     continue
 
             if self._current_char == "[":
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('[[', TokenType.DOUBLE_OPEN_BRACKET, self.context)
+                cursor_advanced = self.peek_reserved('[[', TokenType.DOUBLE_OPEN_BRACKET)
                 if cursor_advanced:
                     continue
 
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('[', TokenType.OPEN_BRACKET, self.context)
+                cursor_advanced = self.peek_reserved('[', TokenType.OPEN_BRACKET)
                 if cursor_advanced:
                     continue
 
             if self._current_char == "]":
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved(']]', TokenType.DOUBLE_CLOSE_BRACKET, self.context)
+                cursor_advanced = self.peek_reserved(']]', TokenType.DOUBLE_CLOSE_BRACKET)
                 if cursor_advanced:
                     continue
 
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved(']', TokenType.CLOSE_BRACKET, self.context)
+                cursor_advanced = self.peek_reserved(']', TokenType.CLOSE_BRACKET)
                 if cursor_advanced:
                     continue
 
             if self._current_char == ",":
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved(',', TokenType.COMMA, self.context)
+                cursor_advanced = self.peek_reserved(',', TokenType.COMMA)
                 if cursor_advanced:
                     continue
 
             if self._current_char == ".":
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('.', TokenType.DOT_OP, self.context)
+                cursor_advanced = self.peek_reserved('.', TokenType.DOT_OP)
                 if cursor_advanced:
                     continue
 
             if self._current_char == '~':
-                cursor_advanced, is_end_of_file, self._current_char = peek.reserved('~', TokenType.TERMINATOR, self.context)
+                cursor_advanced = self.peek_reserved('~', TokenType.TERMINATOR)
                 if cursor_advanced:
                     continue
 

--- a/src/lexer/lexer_components/peek.py
+++ b/src/lexer/lexer_components/peek.py
@@ -264,7 +264,7 @@ def comments(context: tuple[list[str], list[int], str, list[Token], list[DelimEr
 
 
 def int_float(context: tuple[list[str], list[int], str, list[Token], list[DelimError]],
-                             negative=False) -> tuple[bool, str]:
+              negative=False, start_pos: tuple[int, int] = None) -> tuple[bool, str]:
     lines, position, current_char, tokens, logs = context
 
     temp_num = "-"+current_char if negative else current_char
@@ -291,7 +291,7 @@ def int_float(context: tuple[list[str], list[int], str, list[Token], list[DelimE
             context = lines, position, current_char, tokens, logs
 
             corrected_value = temp_num
-            starting_position = (position[0], position[1] - len(temp_num) + 1)
+            starting_position = (position[0], position[1] - len(temp_num) + 1) if start_pos is None else start_pos
             ending_position = (position[0], position[1])
 
             tokens.append(Token(corrected_value, TokenType.INT_LITERAL, starting_position, ending_position))
@@ -321,13 +321,13 @@ def int_float(context: tuple[list[str], list[int], str, list[Token], list[DelimE
                     context = lines, position, current_char, tokens, logs
 
                     corrected_value = temp_num
-                    starting_position = tuple([position[0], position[1] - len(temp_num) + 1])
+                    starting_position = tuple([position[0], position[1] - len(temp_num) + 1]) if start_pos is None else start_pos
                     ending_position = tuple(position)
 
                     # has no numbers after decimal point
                     if temp_num[-1:] == '.':
                         corrected_value = temp_num + '0'
-                        starting_position = tuple([position[0], position[1] - len(temp_num) + 1])
+                        starting_position = tuple([position[0], position[1] - len(temp_num) + 1]) if start_pos is None else start_pos
                         ending_position = tuple(position)
                         logs.append(
                             GenericError(Error.MISSING_TRAILING_ZERO_FLOAT, starting_position, ending_position,

--- a/src/lexer/token.py
+++ b/src/lexer/token.py
@@ -164,7 +164,7 @@ class Token:
         self._end_position = end_position
 
     def __repr__(self):
-        return f"Token(lexeme='{self.lexeme}', token='{self.token}', position={self.position}, end_position={self.end_position})"
+        return self._lexeme
 
     def __str__(self):
         return self._lexeme

--- a/src/lexer/token.py
+++ b/src/lexer/token.py
@@ -166,6 +166,9 @@ class Token:
     def __repr__(self):
         return f"Token(lexeme='{self.lexeme}', token='{self.token}', position={self.position}, end_position={self.end_position})"
 
+    def __str__(self):
+        return self._lexeme
+
     @property
     def lexeme(self) -> str:
         return self._lexeme

--- a/src/parser/__init__.py
+++ b/src/parser/__init__.py
@@ -2,8 +2,3 @@
 from .parser import Parser
 from .productions import *
 
-Parser
-Program
-Fwunc
-Cwass
-GwobawDec

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -3,11 +3,12 @@ from ..lexer import print_lex
 
 if __name__ == "__main__":
     sc = """
-    gwobaw aqua-chan[3] = {1+1*1, (2+2)*2}~
-    gwobaw shion-chan = 1+-aqua~
-        gwobaw ojou-chan = -5- -1~
-        gwobaw sora-senpai = "tokino '| nickname |' sora"~
+    gwobaw aqua-chan-dono = ~
     """
+    # gwobaw aqua-chan[] = {1+1*1, (2+2)*2}~
+    # gwobaw shion-chan = 1+-aqua~
+    # gwobaw ojou-chan = -5- -1~
+    # gwobaw sora-senpai = "tokino '| nickname |' sora"~
 
     source: list[str] = [line if line else '\n' for line in sc.split("\n")]
     l = print_lex(source)

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -4,7 +4,7 @@ from ..lexer import Lexer
 if __name__ == "__main__":
     sc = """
     gwobaw shion-chan = -aqua~
-    gwobaw aqua-chan[] = {aqua,4,-shion,2,ojou}~
+    gwobaw aqua-chan[] = {aqua,4,-shion,"i love you",ojou}~
     gwobaw ojou-chan-dono = 5~
     """
     source: list[str] = [line if line else '\n' for line in sc.split("\n")]

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -4,7 +4,7 @@ from ..lexer import Lexer
 if __name__ == "__main__":
     sc = """
     gwobaw shion-chan~
-    gwobaw aqua-chan = 5~
+    gwobaw aqua-chan[] = {5,4,3,2,1}~
     gwobaw ojou-chan-dono = 5~
     """
     source: list[str] = [line if line else '\n' for line in sc.split("\n")]

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -4,7 +4,7 @@ from ..lexer import Lexer
 if __name__ == "__main__":
     sc = """
     gwobaw shion-chan = -aqua~
-    gwobaw aqua-chan[] = {5,4,3,2,1}~
+    gwobaw aqua-chan[] = {aqua,4,-shion,2,ojou}~
     gwobaw ojou-chan-dono = 5~
     """
     source: list[str] = [line if line else '\n' for line in sc.split("\n")]

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -1,5 +1,5 @@
 from .parser import *
-from ..lexer import Lexer, print_lex
+from ..lexer import print_lex
 
 if __name__ == "__main__":
     sc = """
@@ -10,19 +10,9 @@ if __name__ == "__main__":
     """
 
     source: list[str] = [line if line else '\n' for line in sc.split("\n")]
-    max_digit_length = len(str(len(source)))
-    max_width = max(len(line) for line in source) + max_digit_length + 3
-
-    print("-" * (max_width) )
-    for i, line in enumerate(source):
-        line = line if line != '\n' else ''
-        print(f"{i+1:<{max_digit_length}} | {line}")
-    print("-" * (max_width) )
-
     l = print_lex(source)
     if l.errors:
         exit(1)
-
     p = Parser(l.tokens)
     for err in p.errors:
         print(err)

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -4,7 +4,7 @@ from ..lexer import Lexer
 if __name__ == "__main__":
     sc = """
     gwobaw shion-chan~
-    gwobaw aqua-chan[]~
+    gwobaw aqua-chan = 5~
     gwobaw ojou-chan-dono = 5~
     """
     source: list[str] = [line if line else '\n' for line in sc.split("\n")]

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -3,11 +3,11 @@ from ..lexer import Lexer, print_lex
 
 if __name__ == "__main__":
     sc = """
-    gwobaw shion-chan = 1+1~
-    gwobaw aqua-chan[] = {1+1, 2+-2, 3+3*3, 4/4-4}~
+    gwobaw aqua-chan[] = {1==1, 2-2!=fax, aqua>=shion+-ojou, 4/4%4}~
+    gwobaw shion-chan = 1+-aqua~
+    gwobaw ojou-chan =-5--1~
+    gwobaw sora-senpai = "tokino '| -nickname |' sora"~
     """
-    # gwobaw sora-senpai = "tokino '| -nickname |' sora"~
-    # gwobaw ojou-chan-dono = -5----1~
 
     source: list[str] = [line if line else '\n' for line in sc.split("\n")]
     max_digit_length = len(str(len(source)))

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -1,11 +1,12 @@
 from .parser import *
-from ..lexer import Lexer
+from ..lexer import Lexer, print_lex
 
 if __name__ == "__main__":
     sc = """
     gwobaw shion-chan = -aqua~
-    gwobaw aqua-chan[] = {aqua,4,-shion,"i love you",ojou}~
-    gwobaw ojou-chan-dono = 5~
+    gwobaw sora-senpai = "tokino '||' sora"~
+    gwobaw aqua-chan[] = {aqua, "start|-5|love|-4|end", -shion, "i love you", ojou}~
+    gwobaw ojou-chan-dono = -5~
     """
     source: list[str] = [line if line else '\n' for line in sc.split("\n")]
     max_digit_length = len(str(len(source)))
@@ -17,10 +18,7 @@ if __name__ == "__main__":
         print(f"{i+1:<{max_digit_length}} | {line}")
     print("-" * (max_width) )
 
-    l = Lexer(source)
-    if len(l.errors) > 0:
-        print(l.print_error_logs())
-        exit(1)
+    l = print_lex(source)
 
     p = Parser(l.tokens)
     for err in p.errors:

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -3,10 +3,10 @@ from ..lexer import print_lex
 
 if __name__ == "__main__":
     sc = """
-    gwobaw aqua-chan[] = {1==1, 2-2!=fax, aqua>=shion+-ojou, 4/4%4}~
+    gwobaw aqua-chan[] = {1+1*1, (2+2)*2}~
     gwobaw shion-chan = 1+-aqua~
-    gwobaw ojou-chan = -5- -1~
-    gwobaw sora-senpai = "tokino '| -1 |' sora"~
+        gwobaw ojou-chan = -5- -1~
+        gwobaw sora-senpai = "tokino '| nickname |' sora"~
     """
 
     source: list[str] = [line if line else '\n' for line in sc.split("\n")]

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -3,7 +3,7 @@ from ..lexer import Lexer
 
 if __name__ == "__main__":
     sc = """
-    gwobaw shion-chan = aqua~
+    gwobaw shion-chan = -aqua~
     gwobaw aqua-chan[] = {5,4,3,2,1}~
     gwobaw ojou-chan-dono = 5~
     """

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -5,8 +5,8 @@ if __name__ == "__main__":
     sc = """
     gwobaw aqua-chan[] = {1==1, 2-2!=fax, aqua>=shion+-ojou, 4/4%4}~
     gwobaw shion-chan = 1+-aqua~
-    gwobaw ojou-chan =-5--1~
-    gwobaw sora-senpai = "tokino '| -nickname |' sora"~
+    gwobaw ojou-chan = -5- -1~
+    gwobaw sora-senpai = "tokino '| -1 |' sora"~
     """
 
     source: list[str] = [line if line else '\n' for line in sc.split("\n")]
@@ -20,6 +20,8 @@ if __name__ == "__main__":
     print("-" * (max_width) )
 
     l = print_lex(source)
+    if l.errors:
+        exit(1)
 
     p = Parser(l.tokens)
     for err in p.errors:

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -3,11 +3,12 @@ from ..lexer import Lexer, print_lex
 
 if __name__ == "__main__":
     sc = """
-    gwobaw shion-chan = -aqua~
-    gwobaw sora-senpai = "tokino '||' sora"~
-    gwobaw aqua-chan[] = {aqua, "start|-5|love|-4|end", -shion, "i love you", ojou}~
-    gwobaw ojou-chan-dono = -5~
+    gwobaw shion-chan = 1+1~
+    gwobaw aqua-chan[] = {1+1, 2+-2, 3+3*3, 4/4-4}~
     """
+    # gwobaw sora-senpai = "tokino '| -nickname |' sora"~
+    # gwobaw ojou-chan-dono = -5----1~
+
     source: list[str] = [line if line else '\n' for line in sc.split("\n")]
     max_digit_length = len(str(len(source)))
     max_width = max(len(line) for line in source) + max_digit_length + 3

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -3,9 +3,9 @@ from ..lexer import print_lex
 
 if __name__ == "__main__":
     sc = """
-    gwobaw aqua-chan-dono = ~
+    gwobaw aqua-chan-dono = 1+1~
+    gwobaw aqua-chan[] = {1+1*1, (2+2)*2}~
     """
-    # gwobaw aqua-chan[] = {1+1*1, (2+2)*2}~
     # gwobaw shion-chan = 1+-aqua~
     # gwobaw ojou-chan = -5- -1~
     # gwobaw sora-senpai = "tokino '| nickname |' sora"~

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -3,7 +3,7 @@ from ..lexer import Lexer
 
 if __name__ == "__main__":
     sc = """
-    gwobaw shion-chan~
+    gwobaw shion-chan = aqua~
     gwobaw aqua-chan[] = {5,4,3,2,1}~
     gwobaw ojou-chan-dono = 5~
     """
@@ -23,3 +23,5 @@ if __name__ == "__main__":
         exit(1)
 
     p = Parser(l.tokens)
+    for err in p.errors:
+        print(err)

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -3,7 +3,7 @@ from ..lexer import print_lex
 
 if __name__ == "__main__":
     sc = """
-    gwobaw aqua-chan[] = {1+1*1, (2+2)*2}~
+    gwobaw aqua-chan[3] = {1+1*1, (2+2)*2}~
     gwobaw shion-chan = 1+-aqua~
         gwobaw ojou-chan = -5- -1~
         gwobaw sora-senpai = "tokino '| nickname |' sora"~

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -3,18 +3,9 @@ from ..lexer import Lexer
 
 if __name__ == "__main__":
     sc = """
-    fwunc shion-chan() [[
-
-    ]]
-
-    fwunc shion-chan() [[
-
-    ]]
-
-    fwunc shion-chan() [[
-
-    ]]
-
+    gwobaw shion-chan~
+    gwobaw aqua-chan[]~
+    gwobaw ojou-chan-dono = 5~
     """
     source: list[str] = [line if line else '\n' for line in sc.split("\n")]
     max_digit_length = len(str(len(source)))

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -191,11 +191,11 @@ class Parser:
 
     def parse_expression_statement(self):
         '''
-        parse an expression statement
+        This is a common interface for handling all types of expression statements
         Expressions can be:
-        - literal
-        - prefix expression
-        - infix expression
+        - literal int, string, float, bool
+        - prefix expression (int, string, float, bool)
+        - infix expression (int, string, float, bool)
         '''
         es = ExpressionStatement()
         tmp = self.parse_expression(Precedence.LOWEST)
@@ -206,9 +206,9 @@ class Parser:
         '''
         parse expressions.
         Expressions can be:
-        - literal
-        - prefix expression
-        - infix expression
+        - literal int, string, float, bool
+        - prefix expression (int, string, float, bool)
+        - infix expression (int, string, float, bool)
         '''
         if isinstance(self.curr_tok.token, UniqueTokenType):
             prefix = self.prefix_parse_fns["IDENTIFIER"]

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -298,7 +298,7 @@ class Parser:
         This is because negative int/float literals are tokenized
         '''
         pe = PrefixExpression()
-        pe.op = self.curr_tok.token
+        pe.op = self.curr_tok
 
         self.advance()
         pe.right = self.parse_expression(PREFIX)

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -90,11 +90,16 @@ class Parser:
         '''
         # prefixes
         self.register_prefix("IDENTIFIER", self.parse_identifier)
-        self.register_prefix(TokenType.INT_LITERAL, self.parse_int_lit)
         self.register_prefix(TokenType.DASH, self.parse_prefix_expression)
         self.register_prefix(TokenType.OPEN_BRACE, self.parse_array)
-        self.register_prefix(TokenType.STRING_LITERAL, self.parse_string_lit)
         self.register_prefix(TokenType.STRING_PART_START, self.parse_string_parts)
+
+        # literals (just returns curr_tok)
+        self.register_prefix(TokenType.INT_LITERAL, self.parse_literal)
+        self.register_prefix(TokenType.STRING_LITERAL, self.parse_literal)
+        self.register_prefix(TokenType.FLOAT_LITERAL, self.parse_literal)
+        self.register_prefix(TokenType.FAX, self.parse_literal)
+        self.register_prefix(TokenType.CAP, self.parse_literal)
 
         # infixes
 
@@ -299,16 +304,7 @@ class Parser:
         return sf
 
 
-    def parse_string_lit(self):
-        'returns the current token'
-        return self.curr_tok
-    def parse_float_lit(self):
-        'returns the current token'
-        return self.curr_tok
-    def parse_identifier(self):
-        'returns the current token'
-        return self.curr_tok
-    def parse_int_lit(self):
+    def parse_literal(self):
         'returns the current token'
         return self.curr_tok
 

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -105,6 +105,7 @@ class Parser:
         self.register_prefix(TokenType.DASH, self.parse_prefix_expression)
         self.register_prefix(TokenType.OPEN_BRACE, self.parse_array)
         self.register_prefix(TokenType.STRING_PART_START, self.parse_string_parts)
+        self.register_prefix(TokenType.OPEN_PAREN, self.parse_grouped_expressions)
 
         # literals (just returns curr_tok)
         self.register_prefix("IDENTIFIER", self.parse_literal)
@@ -299,10 +300,18 @@ class Parser:
         pe = PrefixExpression()
         pe.prefix_tok = self.curr_tok
         pe.op = self.curr_tok.token
+
         self.advance()
         pe.right = self.parse_expression(PREFIX)
         return pe
     def parse_infix_expression(self, left):
+        '''
+        parse infix expressions.
+        eg.
+        1 + 2
+        1 != 2
+        shion + aqua == fax
+        '''
         ie = InfixExpression()
         ie.left = left
         ie.infix_tok = self.curr_tok
@@ -312,7 +321,18 @@ class Parser:
         self.advance()
         ie.right = self.parse_expression(precedence)
         return ie
-
+    def parse_grouped_expressions(self):
+        '''
+        parse grouped expressions
+        eg.
+        (1 + 2)
+        (shion + aqua) + ojou
+        '''
+        self.advance()
+        expr = self.parse_expression(LOWEST)
+        if not self.expect_peek(TokenType.CLOSE_PAREN):
+            return None
+        return expr
     def parse_array(self):
         al = ArrayLiteral()
         self.advance() # consume the opening brace

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -39,22 +39,93 @@ class Parser:
         return p
 
     def parse_statement(self):
-        match self.curr_tok.token:
-            case TokenType.FWUNC:
-                return self.parse_function()
-            case TokenType.CWASS:
-                return self.parse_class()
-            case _:
-                if self.curr_tok.token.token.startswith("IDENTIFIER"):
+        while not self.curr_tok_is(TokenType.EOF):
+            match self.curr_tok.token:
+                case TokenType.FWUNC:
+                    return self.parse_function()
+                case TokenType.CWASS:
+                    return self.parse_class()
+                case TokenType.GWOBAW:
                     return self.parse_declaration()
-                else:
-                    self.errors.append(f"Expected function/class/variable/constant declaration, got {self.curr_tok.lexeme}")
-                    return None
+                case _:
+                    self.errors.append(f"Expected global function/class/variable/constant declaration, got {self.curr_tok.lexeme}")
+                    self.advance()
     
+    def parse_declaration(self):
+        d = Declaration()
+
+        if not self.expect_peek_identifier():
+            return None
+        d.id = self.curr_tok
+
+        if not self.expect_peek(TokenType.DASH):
+            return None
+        data_types = [
+            TokenType.CHAN,
+            TokenType.KUN,
+            TokenType.SAMA,
+            TokenType.SENPAI,
+            TokenType.SAN
+        ]
+        if not self.expect_peek_in(data_types):
+            return None
+        d.dtype = self.curr_tok
+
+        # -dono if constant
+        if self.expect_peek(TokenType.DASH):
+            if not self.expect_peek(TokenType.DONO):
+                return None
+            d.is_const = True
+
+            if not self.expect_peek(TokenType.ASSIGNMENT_OPERATOR):
+                return None
+            # TODO: parse expressions
+            self.advance()
+            d.value = self.curr_tok
+            return d
+
+        # variable declaration without value
+        if self.expect_peek(TokenType.TERMINATOR):
+            return d
+
+        # variable declaration with value
+        if not self.expect_peek(TokenType.ASSIGNMENT_OPERATOR):
+            return None
+        # TODO: parse expressions
+        self.advance()
+        d.value = self.curr_tok
+
+        return d
+
+
     def parse_function(self):
         pass
     def parse_class(self):
         pass
-    def parse_declaration(self):
-        pass
+
+    # helper methods
+    def curr_tok_is(self, token_type: TokenType) -> bool:
+        return self.curr_tok.token == token_type
+    def peek_tok_is(self, token_type: TokenType) -> bool:
+        return self.peek_tok.token == token_type
+    def expect_peek(self, token_type: TokenType) -> bool:
+        if self.peek_tok_is(token_type):
+            self.advance()
+            return True
+        else:
+            return False
+    def peek_tok_is_in(self, token_types: list[TokenType]) -> bool:
+        return self.peek_tok.token in token_types
+    def expect_peek_in(self, token_types: list[TokenType]) -> bool:
+        if self.peek_tok_is_in(token_types):
+            self.advance()
+            return True
+        else:
+            return False
+    def expect_peek_identifier(self) -> bool:
+        if self.peek_tok.token.token.startswith("IDENTIFIER"):
+            self.advance()
+            return True
+        else:
+            return False
 

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -233,25 +233,20 @@ class Parser:
         left_exp = prefix()
         return left_exp
 
-    def parse_identifier(self):
-        'returns the current token'
-        return self.curr_tok
-    def parse_int_lit(self):
-        'returns the current token'
-        return self.curr_tok
-    def parse_array(self):
-        al = ArrayLiteral()
-        self.advance() # consume the opening brace
-        while not self.curr_tok_is_in([TokenType.CLOSE_BRACE, TokenType.TERMINATOR, TokenType.EOF]):
-            al.elements.append(self.parse_expression(Precedence.LOWEST))
-            if not self.expect_peek(TokenType.COMMA):
-                break
-            self.advance()
+    ### block statement parsers
+    def parse_function(self):
+        pass
+    def parse_class(self):
+        pass
+    def parse_if_statement(self):
+        pass
+    def parse_while_statement(self):
+        'this includes do while block statements'
+        pass
+    def parse_for_statement(self):
+        pass
 
-        if not self.expect_peek(TokenType.CLOSE_BRACE):
-            return None
-        return al
-
+    ### atomic parsers
     def parse_prefix_expression(self):
         '''
         parse prefix expressions.
@@ -264,12 +259,33 @@ class Parser:
         self.advance()
         pe.right = self.parse_expression(Precedence.PREFIX)
         return pe
-        
+    def parse_array(self):
+        al = ArrayLiteral()
+        self.advance() # consume the opening brace
+        while not self.curr_tok_is_in([TokenType.CLOSE_BRACE, TokenType.TERMINATOR, TokenType.EOF]):
+            al.elements.append(self.parse_expression(Precedence.LOWEST))
+            if not self.expect_peek(TokenType.COMMA):
+                break
+            self.advance()
 
-    def parse_function(self):
+        if not self.expect_peek(TokenType.CLOSE_BRACE):
+            return None
+        return al
+    def parse_string_parts(self):
         pass
-    def parse_class(self):
-        pass
+
+    def parse_string_lit(self):
+        'returns the current token'
+        return self.curr_tok
+    def parse_float_lit(self):
+        'returns the current token'
+        return self.curr_tok
+    def parse_identifier(self):
+        'returns the current token'
+        return self.curr_tok
+    def parse_int_lit(self):
+        'returns the current token'
+        return self.curr_tok
 
     ### helper methods
     # registering prefix and infix functions to parse certain token types

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -1,3 +1,28 @@
+'''
+OVERVIEW: 
+
+1. Statements: can be declarations, expressions, or block statements
+
+2. Declarations are simply global/local function/class/variable/constant declarations
+    - on a global scope, only declarations are allowed
+
+3. Expressions can be:
+    - literal int, string, float, bool
+    - function call
+    - return statements
+    - prefix expression (int, string, float, bool)
+        - negative idents
+    - infix expression (int, string, float, bool)
+        - math operations
+        - comparisons
+        - equality checks
+
+4. block statements are statements with bodies:
+    - if statements
+    - while and do while statements
+    - for statements
+'''
+
 from typing import Callable
 from enum import Enum
 

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -94,6 +94,7 @@ class Parser:
         self.register_prefix(TokenType.INT_LITERAL, self.parse_int_lit)
         self.register_prefix(TokenType.DASH, self.parse_prefix_expression)
         self.register_prefix(TokenType.OPEN_BRACE, self.parse_array)
+        self.register_prefix(TokenType.STRING_LITERAL, self.parse_string_lit)
 
         # infixes
 

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -2,3 +2,36 @@ from src.lexer.token import Token, TokenType
 from src.parser.productions import *
 
 class Parser:
+    def __init__(self, tokens: list[Token]):
+        self.tokens = [token for token in tokens if token.token != TokenType.WHITESPACE]
+        self.tokens.append(Token("", TokenType.EOF, (0, 0), (0, 0)))
+
+
+        self.pos = 0
+        self.curr_tok = self.tokens[self.pos]
+        self.peek_tok = self.tokens[self.pos + 1]
+
+        program = self.parse_program()
+        program.print()
+
+    def advance(self):
+        if self.curr_tok.token == TokenType.EOF:
+            return
+
+        if self.peek_tok.token == TokenType.EOF:
+            self.curr_tok = self.peek_tok
+            self.pos += 1
+            return
+
+        self.pos += 1
+        self.curr_tok = self.peek_tok
+        self.peek_tok = self.tokens[self.pos + 1]
+
+    def parse_program(self) -> Program:
+        p = Program()
+
+        while self.curr_tok.token != TokenType.EOF:
+            p.statements.append(self.curr_tok)
+            self.advance()
+
+        return p

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -1,8 +1,8 @@
 '''
-OVERVIEW: 
-
+PLEASE READ!
 Headers are prepended by '###' so just search for that
 
+Overview:
 1. Statements: can be declarations, expressions, or block statements
 
 2. Declarations are simply global/local function/class/variable/constant declarations
@@ -24,9 +24,7 @@ Headers are prepended by '###' so just search for that
     - while and do while statements
     - for statements
 '''
-
 from typing import Callable
-from enum import Enum
 
 from src.lexer.token import Token, TokenType, UniqueTokenType
 from src.parser.productions import *
@@ -257,6 +255,7 @@ class Parser:
     def parse_for_statement(self):
         pass
 
+    ### expression parsers
     def parse_expression(self, precedence):
         '''
         parse expressions.
@@ -289,9 +288,8 @@ class Parser:
             left_exp = infix(left_exp)
 
         return left_exp
-
-    ### expression parsers
-    # PLEASE USE self.parse_expression(precedence) to use these methods in other parsers
+    # PLEASE USE self.parse_expression(precedence)
+    # to use the 3 methods below in other parsers.
     # DO NOT USE THESE 3 METHODS DIRECTLY
     def parse_prefix_expression(self):
         '''
@@ -337,6 +335,8 @@ class Parser:
         return expr
 
     ### atomic parsers
+    # unlike the above 3 expressions parsers,
+    # these are made to be used in other parsers
     def parse_array(self):
         al = ArrayLiteral()
         self.advance() # consume the opening brace
@@ -369,7 +369,6 @@ class Parser:
 
         sf.end = self.curr_tok
         return sf
-
     def parse_literal(self):
         'returns the current token'
         return self.curr_tok
@@ -378,9 +377,8 @@ class Parser:
     # registering prefix and infix functions to parse certain token types
     def register_prefix(self, token_type: str | TokenType, fn: Callable):
         self.prefix_parse_fns[token_type] = fn
-    def register_infix(self, token_type: str, fn: Callable):
+    def register_infix(self, token_type: str | TokenType, fn: Callable):
         self.infix_parse_fns[token_type] = fn
-
     # keeping track of tokens
     def curr_tok_is(self, token_type: TokenType) -> bool:
         return self.curr_tok.token == token_type
@@ -408,7 +406,7 @@ class Parser:
             return True
         else:
             return False
-
+    # to keep track of precedence of tokens
     def curr_precedence(self):
         if self.curr_tok.token in precedence_map:
             return precedence_map[self.curr_tok.token]

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -244,6 +244,19 @@ class Parser:
         self.advance()
         return d
 
+    ### block statement parsers
+    def parse_function(self):
+        pass
+    def parse_class(self):
+        pass
+    def parse_if_statement(self):
+        pass
+    def parse_while_statement(self):
+        'this includes do while block statements'
+        pass
+    def parse_for_statement(self):
+        pass
+
     def parse_expression(self, precedence):
         '''
         parse expressions.
@@ -277,20 +290,9 @@ class Parser:
 
         return left_exp
 
-    ### block statement parsers
-    def parse_function(self):
-        pass
-    def parse_class(self):
-        pass
-    def parse_if_statement(self):
-        pass
-    def parse_while_statement(self):
-        'this includes do while block statements'
-        pass
-    def parse_for_statement(self):
-        pass
-
-    ### atomic parsers
+    ### expression parsers
+    # PLEASE USE self.parse_expression(precedence) to use these methods in other parsers
+    # DO NOT USE THESE 3 METHODS DIRECTLY
     def parse_prefix_expression(self):
         '''
         parse prefix expressions.
@@ -333,6 +335,8 @@ class Parser:
         if not self.expect_peek(TokenType.CLOSE_PAREN):
             return None
         return expr
+
+    ### atomic parsers
     def parse_array(self):
         al = ArrayLiteral()
         self.advance() # consume the opening brace
@@ -365,7 +369,6 @@ class Parser:
 
         sf.end = self.curr_tok
         return sf
-
 
     def parse_literal(self):
         'returns the current token'

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -298,7 +298,6 @@ class Parser:
         This is because negative int/float literals are tokenized
         '''
         pe = PrefixExpression()
-        pe.prefix_tok = self.curr_tok
         pe.op = self.curr_tok.token
 
         self.advance()

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -5,6 +5,7 @@ class Parser:
     def __init__(self, tokens: list[Token]):
         self.tokens = [token for token in tokens if token.token != TokenType.WHITESPACE]
         self.tokens.append(Token("", TokenType.EOF, (0, 0), (0, 0)))
+        self.errors: list = []
 
 
         self.pos = 0
@@ -31,7 +32,29 @@ class Parser:
         p = Program()
 
         while self.curr_tok.token != TokenType.EOF:
-            p.statements.append(self.curr_tok)
+            statement = self.parse_statement()
+            if statement:
+                p.statements.append(statement)
             self.advance()
-
         return p
+
+    def parse_statement(self):
+        match self.curr_tok.token:
+            case TokenType.FWUNC:
+                return self.parse_function()
+            case TokenType.CWASS:
+                return self.parse_class()
+            case _:
+                if self.curr_tok.token.token.startswith("IDENTIFIER"):
+                    return self.parse_declaration()
+                else:
+                    self.errors.append(f"Expected function/class/variable/constant declaration, got {self.curr_tok.lexeme}")
+                    return None
+    
+    def parse_function(self):
+        pass
+    def parse_class(self):
+        pass
+    def parse_declaration(self):
+        pass
+

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -1,6 +1,8 @@
 '''
 OVERVIEW: 
 
+Headers are prepended by '###' so just search for that
+
 1. Statements: can be declarations, expressions, or block statements
 
 2. Declarations are simply global/local function/class/variable/constant declarations
@@ -322,6 +324,6 @@ class Parser:
         else:
             return False
 
-    # error functions
+    ### error methods
     def no_prefix_parse_fn_error(self, token_type):
         self.errors.append(f"no prefix parsing function found for {token_type}")

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -67,9 +67,8 @@ class Parser:
         self.infix_parse_fns: dict = {}
         self.register_init()
 
-        self.program: Program = Program()
-        self.parse_program()
-        self.program.print()
+        self.program = self.parse_program()
+        print(self.program)
 
     def advance(self):
         if self.curr_tok.token == TokenType.EOF:
@@ -99,21 +98,23 @@ class Parser:
 
         # infixes
 
-    def parse_program(self):
+    def parse_program(self) -> Program:
         '''
         parse the entire program
         '''
+        p = Program()
         while not self.curr_tok_is(TokenType.EOF):
             match self.curr_tok.token:
                 case TokenType.FWUNC:
-                    self.program.functions.append(self.parse_function())
+                    p.functions.append(self.parse_function())
                 case TokenType.CWASS:
-                    self.program.classes.append(self.parse_class())
+                    p.classes.append(self.parse_class())
                 case TokenType.GWOBAW:
-                    self.program.globals.append(self.parse_declaration())
+                    p.globals.append(self.parse_declaration())
                 case _:
                     self.errors.append(f"Expected global function/class/variable/constant declaration, got {self.curr_tok.lexeme}")
                     self.advance()
+        return p
 
     def parse_declaration(self):
         '''

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -7,7 +7,7 @@ class PrefixExpression:
     op = None
     right = None
     def __str__(self):
-        return f"{self.op}, {self.right.lexeme}"
+        return f"{self.op} {self.right}"
 
 class ExpressionStatement:
     expression = None
@@ -17,7 +17,7 @@ class ArrayLiteral:
     def __str__(self):
         result = "{"
         for e in self.elements:
-            result += f"{e.lexeme}, "
+            result += f"{e}, "
         return result[:-2] + "}"
 
 class ArrayDeclaration:
@@ -29,8 +29,8 @@ class ArrayDeclaration:
     is_const: bool = False
 
     def __str__(self, indent = 0):
-        result =  f"declare: {self.id.lexeme}\n"
-        result += f"{' ' * (indent+4)}type: {self.dtype.lexeme}\n"
+        result =  f"declare: {self.id}\n"
+        result += f"{' ' * (indent+4)}type: {self.dtype}\n"
         if self.value:
             result += f"{' ' * (indent+4)}value: {self.value.expression}\n"
         if self.size:
@@ -48,8 +48,8 @@ class Declaration:
     is_const: bool = False
 
     def __str__(self, indent = 0):
-        result =  f"declare: {self.id.lexeme}\n"
-        result += f"{' ' * (indent+4)}type: {self.dtype.lexeme}\n"
+        result =  f"declare: {self.id}\n"
+        result += f"{' ' * (indent+4)}type: {self.dtype}\n"
         if self.value and self.value.expression:
             result += f"{' ' * (indent+4)}value: {self.value.expression}\n"
         if self.is_const:

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -9,6 +9,30 @@ class PrefixExpression:
     def __str__(self):
         return f"{self.op} {self.right}"
 
+class InfixExpression:
+    left = None
+    op = None
+    right = None
+    def __str__(self):
+        return f"({self.left} {self.op} {self.right})"
+
+class StringFmt:
+    def __init__(self):
+        self.start = None
+        self.mid = []
+        self.exprs = []
+        self.end = None
+
+    def __str__(self):
+        result = f"\"{self.start.lexeme[1:-1]}"
+        for m,e in zip(self.mid, self.exprs):
+            result += f"| {e} |"
+            result += f"{m.lexeme[1:-1]}"
+        if self.exprs:
+            result += f"| {self.exprs[-1]} |"
+        result += f"{self.end.lexeme[1:-1]}\""
+        return result
+
 class ArrayLiteral:
     elements = []
     def __str__(self):

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -1,6 +1,14 @@
 '''
-All productions must have an as_iter() method
+All productions must have an __str__() method
 '''
+
+class PrefixExpression:
+    prefix_tok = None
+    op = None
+    right = None
+
+class ExpressionStatement:
+    expression = None
 
 class Declaration:
     id = None
@@ -11,8 +19,8 @@ class Declaration:
     def __str__(self, indent = 0):
         result =  f"declare: {self.id.lexeme}\n"
         result += f"{' ' * (indent+4)}type: {self.dtype.lexeme}\n"
-        if self.value:
-            result += f"{' ' * (indent+4)}value: {self.value.lexeme}\n"
+        if self.value and self.value.expression:
+            result += f"{' ' * (indent+4)}value: {self.value.expression}\n"
         if self.is_const:
             result += f"{' ' * (indent+4)}constant\n"
         return result
@@ -29,7 +37,6 @@ class Class:
     body: list = []
     properties: list = []
     methods: list = []
-
 
 class Program:
     statements: list = []

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -4,3 +4,9 @@ from src.lexer.token import Token
 All productions must have an as_iter() method
 '''
 
+class Program:
+    statements: list[Token] = []
+
+    def print(self):
+        for statement in self.statements:
+            print(statement)

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -4,7 +4,6 @@ All productions must have an __str__() method
 
 class PrefixExpression:
     def __init__(self):
-        self.prefix_tok = None
         self.op = None
         self.right = None
 

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -1,22 +1,30 @@
-from src.lexer.token import Token
-
 '''
 All productions must have an as_iter() method
 '''
 
 class Declaration:
-    id: Token
-    dtype: Token
-    value: Token
+    id = None
+    dtype = None
+    value = None
+    is_const: bool = False
+
+    def __str__(self, indent = 0):
+        result =  f"declare: {self.id.lexeme}\n"
+        result += f"{' ' * (indent+4)}type: {self.dtype.lexeme}\n"
+        if self.value:
+            result += f"{' ' * (indent+4)}value: {self.value.lexeme}\n"
+        if self.is_const:
+            result += f"{' ' * (indent+4)}constant\n"
+        return result
 
 class Function:
-    id: Token
-    rtype: Token
+    id = None
+    rtype = None
     params: list = []
     body: list = []
 
 class Class:
-    id: Token
+    id = None
     params: list = []
     body: list = []
     properties: list = []
@@ -24,8 +32,8 @@ class Class:
 
 
 class Program:
-    statements: list[Token] = []
+    statements: list = []
 
     def print(self):
         for statement in self.statements:
-            print(statement.token)
+            print(statement)

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -58,9 +58,9 @@ class ArrayDeclaration:
         result += f"{' ' * (indent+4)}type: {self.dtype}\n"
         if self.value:
             result += f"{' ' * (indent+4)}value: {self.value}\n"
-        if self.size:
+        if self.size is not None:
             result += f"{' ' * (indent+4)}size: {self.size}\n"
-        if self.length:
+        if self.length is not None:
             result += f"{' ' * (indent+4)}length: {self.length}\n"
         if self.is_const:
             result += f"{' ' * (indent+4)}constant\n"

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -4,9 +4,28 @@ from src.lexer.token import Token
 All productions must have an as_iter() method
 '''
 
+class Declaration:
+    id: Token
+    dtype: Token
+    value: Token
+
+class Function:
+    id: Token
+    rtype: Token
+    params: list = []
+    body: list = []
+
+class Class:
+    id: Token
+    params: list = []
+    body: list = []
+    properties: list = []
+    methods: list = []
+
+
 class Program:
     statements: list[Token] = []
 
     def print(self):
         for statement in self.statements:
-            print(statement)
+            print(statement.token)

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -6,9 +6,40 @@ class PrefixExpression:
     prefix_tok = None
     op = None
     right = None
+    def __str__(self):
+        return f"{self.op}, {self.right.lexeme}"
 
 class ExpressionStatement:
     expression = None
+
+class ArrayLiteral:
+    elements = []
+    def __str__(self):
+        result = "{"
+        for e in self.elements:
+            result += f"{e.lexeme}, "
+        return result[:-2] + "}"
+
+class ArrayDeclaration:
+    id = None
+    dtype = None
+    value = None
+    size = None
+    length = None
+    is_const: bool = False
+
+    def __str__(self, indent = 0):
+        result =  f"declare: {self.id.lexeme}\n"
+        result += f"{' ' * (indent+4)}type: {self.dtype.lexeme}\n"
+        if self.value:
+            result += f"{' ' * (indent+4)}value: {self.value.expression}\n"
+        if self.size:
+            result += f"{' ' * (indent+4)}size: {self.size}\n"
+        if self.length:
+            result += f"{' ' * (indent+4)}length: {self.length}\n"
+        if self.is_const:
+            result += f"{' ' * (indent+4)}constant\n"
+        return result
 
 class Declaration:
     id = None

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -2,10 +2,6 @@
 All productions must have an __str__() method
 '''
 
-class ExpressionStatement:
-    'common interface for expression statements'
-    expression = None
-
 class PrefixExpression:
     prefix_tok = None
     op = None
@@ -33,7 +29,7 @@ class ArrayDeclaration:
         result =  f"declare: {self.id}\n"
         result += f"{' ' * (indent+4)}type: {self.dtype}\n"
         if self.value:
-            result += f"{' ' * (indent+4)}value: {self.value.expression}\n"
+            result += f"{' ' * (indent+4)}value: {self.value}\n"
         if self.size:
             result += f"{' ' * (indent+4)}size: {self.size}\n"
         if self.length:
@@ -51,8 +47,8 @@ class Declaration:
     def __str__(self, indent = 0):
         result =  f"declare: {self.id}\n"
         result += f"{' ' * (indent+4)}type: {self.dtype}\n"
-        if self.value and self.value.expression:
-            result += f"{' ' * (indent+4)}value: {self.value.expression}\n"
+        if self.value and self.value:
+            result += f"{' ' * (indent+4)}value: {self.value}\n"
         if self.is_const:
             result += f"{' ' * (indent+4)}constant\n"
         return result
@@ -71,8 +67,18 @@ class Class:
     methods: list = []
 
 class Program:
-    statements: list = []
+    'the root node of the syntax tree'
+    globals: list = []
+    functions: list = []
+    classes: list = []
 
     def print(self):
-        for statement in self.statements:
-            print(statement)
+        print("globals")
+        for g in self.globals:
+            print(g)
+        print("functions")
+        for fn in self.functions:
+            print(fn)
+        print("classes")
+        for c in self.classes:
+            print(c)

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -3,16 +3,19 @@ All productions must have an __str__() method
 '''
 
 class PrefixExpression:
-    prefix_tok = None
-    op = None
-    right = None
+    def __init__(self):
+        self.prefix_tok = None
+        self.op = None
+        self.right = None
+
     def __str__(self):
         return f"{self.op} {self.right}"
 
 class InfixExpression:
-    left = None
-    op = None
-    right = None
+    def __init__(self):
+        self.left = None
+        self.op = None
+        self.right = None
     def __str__(self):
         return f"({self.left} {self.op} {self.right})"
 
@@ -34,7 +37,8 @@ class StringFmt:
         return result
 
 class ArrayLiteral:
-    elements = []
+    def __init__(self):
+        self.elements = []
     def __str__(self):
         result = "{"
         for e in self.elements:
@@ -42,12 +46,13 @@ class ArrayLiteral:
         return result[:-2] + "}"
 
 class ArrayDeclaration:
-    id = None
-    dtype = None
-    value = None
-    size = None
-    length = None
-    is_const: bool = False
+    def __init__(self):
+        self.id = None
+        self.dtype = None
+        self.value = None
+        self.size = None
+        self.length = None
+        self.is_const: bool = False
 
     def __str__(self, indent = 0):
         result =  f"declare: {self.id}\n"
@@ -63,10 +68,11 @@ class ArrayDeclaration:
         return result
 
 class Declaration:
-    id = None
-    dtype = None
-    value = None
-    is_const: bool = False
+    def __init__(self):
+        self.id = None
+        self.dtype = None
+        self.value = None
+        self.is_const: bool = False
 
     def __str__(self, indent = 0):
         result =  f"declare: {self.id}\n"
@@ -78,31 +84,36 @@ class Declaration:
         return result
 
 class Function:
-    id = None
-    rtype = None
-    params: list = []
-    body: list = []
+    def __init__(self):
+        self.id = None
+        self.rtype = None
+        self.params: list = []
+        self.body: list = []
 
 class Class:
-    id = None
-    params: list = []
-    body: list = []
-    properties: list = []
-    methods: list = []
+    def __init__(self):
+        self.id = None
+        self.params: list = []
+        self.body: list = []
+        self.properties: list = []
+        self.methods: list = []
 
 class Program:
     'the root node of the syntax tree'
-    globals: list = []
-    functions: list = []
-    classes: list = []
+    def __init__(self):
+        self.globals: list = []
+        self.functions: list = []
+        self.classes: list = []
 
-    def print(self):
-        print("globals")
+    def __str__(self):
+        result = "globals:\n"
         for g in self.globals:
-            print(g)
-        print("functions")
+            result += f"{g}\n"
+        result += "functions:\n"
         for fn in self.functions:
-            print(fn)
-        print("classes")
+            result += f"{fn}\n"
+        result += "classes:\n"
         for c in self.classes:
-            print(c)
+            result += f"{c}\n"
+        return result
+

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -2,15 +2,16 @@
 All productions must have an __str__() method
 '''
 
+class ExpressionStatement:
+    'common interface for expression statements'
+    expression = None
+
 class PrefixExpression:
     prefix_tok = None
     op = None
     right = None
     def __str__(self):
         return f"{self.op} {self.right}"
-
-class ExpressionStatement:
-    expression = None
 
 class ArrayLiteral:
     elements = []


### PR DESCRIPTION
closes #74 
> parse constant/variable declaration

closes #76  
> parse binary and unary int/float expressions 

closes #77  
> parse string expressions 

closes #78 
> parse bool expressions 

closes #80  
> Dash `-` and numbers are not tokenized together under certain conditions 

---

### changes
- parser rewrite: logic more concise and easier to read
  - a program contains Statements which can only be: **Declarations**, **Expressions**, or **Block Statements**
    - variable/constant **declarations**
      - i guess return statements also count here
    - math and comparison **expressions**
    - function, class, if else, and looping **block statements**
- simplify and lessen classes representing productions
- abstract lexer communicating with other modules (like peek)
  - it was too verbose since some outside module returns many variables that will be used to modify the properties
  - since it was modifying the properties anyway, the communication between `Lexer` and outside modules are now abstracted into methods that handle setting the properties to whatever was returned, removing the need to put all that into the main body


### new
- parse prefix expressions
  - the only one uwu++ has is `-`
- parse infix expressions
  - keep order of precedence
  - also properly parse grouped expressions
- parse string parts
- parse arrays
- parse literals
- error messages
### etc
- fixed negative number tokenizing
- fixed `[` not being delimited by `]`
- fixed `-` not being delimited by another `-`