### PR TITLE
Feat/parse postfix expressions

### DIFF
--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -19,9 +19,9 @@ if __name__ == "__main__":
         },
         1,
     }~
+    gwobaw ojou-chan = -(1+1)--~
+    gwobaw shion-chan = 1+-aqua--~
     """
-    # gwobaw shion-chan = 1+-aqua~
-    # gwobaw ojou-chan = -5- -1~
     # gwobaw sora-senpai = "tokino '| -nickname |' sora"~
     # gwobaw lap-chan[5]-dono = {1,2,3,4,5,6,7,8,9,10}~
     # gwobaw suba-chan[5] = {2+2, (3+3)*3}~

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
         1,
     }~
     gwobaw ojou-chan = -(1+1)--~
-    gwobaw shion-chan = 1+-aqua--~
+    gwobaw shion-chan = 1+- (1-2) --+3 == 5~
     """
     # gwobaw sora-senpai = "tokino '| -nickname |' sora"~
     # gwobaw lap-chan[5]-dono = {1,2,3,4,5,6,7,8,9,10}~

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -22,6 +22,15 @@ class InfixExpression:
     def __len__(self):
         return 1
 
+class PostfixExpression:
+    def __init__(self):
+        self.left = None
+        self.op = None
+    def __str__(self):
+        return f"{self.left} {self.op}"
+    def __len__(self):
+        return 1
+
 class StringFmt:
     def __init__(self):
         self.start = None


### PR DESCRIPTION
### changes
- expression infix parsing now expects EOF, increment, and decrement (`++`, `--`)  along with terminator `~` to stop parsing

### new
- parse int/floats/parenthesis enclosed expressions with postfix operator (`++`, `--`)