### PR TITLE
Feat/returns and function calls

### DIFF
--- a/constants/constants.py
+++ b/constants/constants.py
@@ -42,7 +42,7 @@ DELIMS = {
     'double_open_bracket': {' ', '\n', *ATOMS['alpha'], '>'},
     'close_bracket': {'[', ' ', '~', ',', ')', '[', ']', '}', *ATOMS['general_operator'], '!', r'&', '|', '.',},
     'double_close_bracket': {' ', '\n', *ATOMS['alpha'], '>'},
-    'unary': {'~', ')', *ATOMS['general_operator'], '!', ' '},
+    'unary': {'|', '~', ')', *ATOMS['general_operator'], '!', ' '},
     'concat': {' ', '"', *ATOMS['alpha']},
     'line': {'\n', ' ', *ATOMS['alpha'], ']'},
     'comma': {*ATOMS['alpha'], ' ', *ATOMS['number'], '"', '-', '\n', '>'},

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
         },
         1,
     }~
-    gwobaw ojou-chan = shion(1, 2, aqua(3+4*5), lap("hello |-name++| world"))~
+    gwobaw ojou-chan = shion(1, 2, aqua(3+4*5), lap("hello |-name--| world"))~
     gwobaw shion-chan = 1+- (1-2) --*3-- --5 == 5~
     """
     # gwobaw sora-senpai = "tokino '| -nickname |' sora"~

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
         },
         1,
     }~
-    gwobaw ojou-chan = ~
+    gwobaw ojou-chan = shion(1, 2, aqua(3+4*5), lap("hello |-name++| world"))~
     gwobaw shion-chan = 1+- (1-2) --*3-- --5 == 5~
     """
     # gwobaw sora-senpai = "tokino '| -nickname |' sora"~

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -3,10 +3,12 @@ from ..lexer import print_lex
 
 if __name__ == "__main__":
     sc = """
-    >.< shape of this should be [3, 2, 1]
-    >.< 3 elements on aqua
-    >.< 2 elements in aqua[1]
-    >.< 1 elements in aqua[0][0]
+    >//<
+        shape of this should be [3, 2, 1]
+        3 elements on aqua
+        2 elements in aqua[1]
+        1 elements in aqua[0][0]
+    >//<
     gwobaw aqua-chan[2][-shion] = {
         {
             {

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -126,7 +126,7 @@ class Parser:
         self.register_prefix(TokenType.OPEN_PAREN, self.parse_grouped_expressions)
 
         # literals (just returns curr_tok)
-        self.register_prefix("IDENTIFIER", self.parse_literal)
+        self.register_prefix("IDENTIFIER", self.parse_ident)
         self.register_prefix(TokenType.INT_LITERAL, self.parse_literal)
         self.register_prefix(TokenType.STRING_LITERAL, self.parse_literal)
         self.register_prefix(TokenType.FLOAT_LITERAL, self.parse_literal)
@@ -390,6 +390,25 @@ class Parser:
             self.unclosed_paren_error(self.curr_tok)
             return None
         return rs
+    def parse_ident(self):
+        'parse function calls'
+        if not self.peek_tok_is(TokenType.OPEN_PAREN):
+            return self.curr_tok
+
+        fc = FnCall()
+        fc.id = self.curr_tok
+        self.advance(2)
+        stop_conditions = [TokenType.CLOSE_PAREN, TokenType.TERMINATOR, TokenType.EOF]
+        while not self.curr_tok_is_in(stop_conditions):
+            fc.args.append(self.parse_expression(LOWEST))
+            if not self.expect_peek(TokenType.COMMA) and not self.peek_tok_is_in(stop_conditions):
+                break
+            self.advance()
+        if not self.curr_tok_is(TokenType.CLOSE_PAREN):
+            self.unclosed_paren_error(self.curr_tok)
+            return None
+        return fc
+
 
     ### atomic parsers
     # unlike the above 3 expressions parsers,

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -391,7 +391,7 @@ class Parser:
             return None
         return rs
     def parse_ident(self):
-        'parse function calls'
+        'parse identifiers which can also be function calls'
         if not self.peek_tok_is(TokenType.OPEN_PAREN):
             return self.curr_tok
 

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -267,7 +267,28 @@ class Parser:
             return None
         return d
 
-    ### block statement parsers
+    ### statement parsers
+    def parse_return_statement(self):
+        'parse return statements'
+        rs = ReturnStatement()
+        self.advance() # consume the return token
+        if not self.expect_peek(TokenType.OPEN_PAREN):
+            self.peek_error(TokenType.OPEN_PAREN)
+            self.advance()
+            return None
+        self.advance() # consume the open paren
+        rs.expr = self.parse_expression(LOWEST)
+        if not self.expect_peek(TokenType.CLOSE_PAREN):
+            self.advance()
+            self.unclosed_paren_error(self.curr_tok)
+            return None
+        self.advance() # consume the close paren
+        if not self.expect_peek(TokenType.TERMINATOR):
+            self.advance()
+            self.unterminated_error(self.curr_tok)
+            return None
+        return rs
+    # block statements
     def parse_function(self):
         pass
     def parse_class(self):
@@ -322,8 +343,8 @@ class Parser:
 
         return left_exp
     # PLEASE USE self.parse_expression(precedence)
-    # to use the 3 methods below in other parsers.
-    # DO NOT USE THESE 3 METHODS DIRECTLY
+    # to use the 4 methods below in other parsers.
+    # DO NOT USE THESE 4 METHODS DIRECTLY
     def parse_prefix_expression(self):
         '''
         parse prefix expressions.
@@ -380,16 +401,11 @@ class Parser:
             self.unclosed_paren_error(self.curr_tok)
             return None
         return expr
-    def parse_return_statement(self):
-        'parse return statements'
-        rs = ReturnStatement()
-        self.advance() # consume the return token
-        rs.expr = self.parse_expression(LOWEST)
-        if not self.expect_peek(TokenType.TERMINATOR):
-            self.advance()
-            self.unclosed_paren_error(self.curr_tok)
-            return None
-        return rs
+
+
+    ### atomic parsers
+    # unlike the above 4 expressions parsers,
+    # these are made to be used in other parsers
     def parse_ident(self):
         'parse identifiers which can also be function calls'
         if not self.peek_tok_is(TokenType.OPEN_PAREN):
@@ -408,11 +424,6 @@ class Parser:
             self.unclosed_paren_error(self.curr_tok)
             return None
         return fc
-
-
-    ### atomic parsers
-    # unlike the above 3 expressions parsers,
-    # these are made to be used in other parsers
     def parse_array(self):
         al = ArrayLiteral()
         self.advance() # consume the opening brace

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -380,6 +380,16 @@ class Parser:
             self.unclosed_paren_error(self.curr_tok)
             return None
         return expr
+    def parse_return_statement(self):
+        'parse return statements'
+        rs = ReturnStatement()
+        self.advance() # consume the return token
+        rs.expr = self.parse_expression(LOWEST)
+        if not self.expect_peek(TokenType.TERMINATOR):
+            self.advance()
+            self.unclosed_paren_error(self.curr_tok)
+            return None
+        return rs
 
     ### atomic parsers
     # unlike the above 3 expressions parsers,

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -2,6 +2,14 @@
 All productions must have an __str__() method
 '''
 
+class ReturnStatement:
+    def __init__(self):
+        self.expr = None
+    def __str__(self):
+        return f"return {self.expr}"
+    def __len__(self):
+        return 1
+
 class PrefixExpression:
     def __init__(self):
         self.op = None

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -136,6 +136,21 @@ class Declaration:
             result += f"{' ' * (indent+4)}constant\n"
         return result
 
+class FnCall:
+    def __init__(self):
+        self.id = None
+        self.args = []
+
+    def __str__(self):
+        result = f"{self.id}("
+        for a in self.args:
+            result += f"{a}, "
+        if self.args:
+            result = result[:-2] + ")"
+        else:
+            result += ")"
+        return result
+
 class Function:
     def __init__(self):
         self.id = None


### PR DESCRIPTION
### changes
- parsing identifiers now can be a function call
  - used to be just returning current token but now preemptively checks for opening parenthesis

### new
- parse return statements
- parse function calls

### etc
- unary operators are delimited by `|` for string parts