### PR TITLE
Feat/parse if else

### DIFF
--- a/src/lexer/token.py
+++ b/src/lexer/token.py
@@ -168,7 +168,7 @@ class Token:
     def __str__(self):
         return self._lexeme
     def print(self, indent = 1):
-        return self._lexeme
+        print(self._lexeme)
 
 
     @property

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -3,27 +3,34 @@ from ..lexer import print_lex
 
 if __name__ == "__main__":
     sc = """
-    >//<
-        shape of this should be [3, 2, 1]
-        3 elements on aqua
-        2 elements in aqua[1]
-        1 elements in aqua[0][0]
-    >//<
-    gwobaw aqua-chan[2][-shion] = {
-        {
-            {
-                (2+2)*2,
-            }
-        }, 
-        {
-            3+3*3,
-            (4+4)*4,
-        },
-        1,
-    }~
-    gwobaw ojou-chan = shion(1, 2, aqua(3+4*5), lap("hello |-name--| world"))~
-    gwobaw shion-chan = 1+- (1-2) --*3-- --5 == 5~
+    iwf (1 == 2) [[
+        aqua-chan = 3~
+    ]] ewse iwf (4 == 5) [[
+        aqua-chan = 6~
+    ]] ewse [[
+        aqua-chan = 7~
+    ]]
     """
+    # >//<
+    # shape of this should be [3, 2, 1]
+    # 3 elements on aqua
+    # 2 elements in aqua[1]
+    # 1 elements in aqua[0][0]
+    # >//<
+    # gwobaw aqua-chan[2][-shion] = {
+    #     {
+    #         {
+    #             (2+2)*2,
+    #         }
+    #     }, 
+    #     {
+    #         3+3*3,
+    #         (4+4)*4,
+    #     },
+    #     1,
+    # }~
+    #     gwobaw ojou-chan = shion(1, 2, aqua(3+4*5), lap("hello |-name--| world"))~
+    #     gwobaw shion-chan = 1+- (1-2) -- == 5 -3-- *-5 ~
     # gwobaw sora-senpai = "tokino '| -nickname |' sora"~
     # gwobaw lap-chan[5]-dono = {1,2,3,4,5,6,7,8,9,10}~
     # gwobaw suba-chan[5] = {2+2, (3+3)*3}~

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -6,28 +6,29 @@ if __name__ == "__main__":
     gwobaw shion-chan = 5+6*7~
     iwf (1 == 2) [[
         aqua-sama = 3~
-        shion-sama = 3~
-        ojou-sama = 3~
-    ]] ewse iwf (4 == 5) [[
-        aqua-sama = 6~
-        shion-sama = 6~
-        ojou-sama = 6~
-    ]] ewse iwf (7 == 8) [[
-        aqua-sama = 9~
-        shion-sama = 9~
-        ojou-sama = 9~
-    ]] ewse iwf (10 == 11) [[
-        aqua-sama = 12~
-        shion-sama = 12~
-        ojou-sama = 12~
-    ]] ewse [[
-        iwf (1 == 2) [[
-            sora-senpai = "nested!"~
-        ]] ewse [[
-            sora-senpai = "if statements!"~
-        ]]
+        shion = 3~
+        wetuwn (ojou)~
     ]]
     """
+#     ewse iwf (4 == 5) [[
+#         aqua-sama = 6~
+#             shion-sama = 6~
+#             ojou-sama = 6~
+#     ]] ewse iwf (7 == 8) [[
+#             aqua-sama = 9~
+#                 shion-sama = 9~
+#                 ojou-sama = 9~
+#         ]] ewse iwf (10 == 11) [[
+#         aqua-sama = 12~
+#             shion-sama = 12~
+#             ojou-sama = 12~
+#     ]] ewse [[
+#     iwf (1 == 2) [[
+#         sora-senpai = "nested!"~
+#     ]] ewse [[
+#             sora-senpai = "if statements!"~
+#         ]]
+# ]]
     # >//<
     # shape of this should be [3, 2, 1]
     # 3 elements on aqua
@@ -59,3 +60,6 @@ if __name__ == "__main__":
     p = Parser(l.tokens)
     for err in p.errors:
         print(err)
+    if p.errors:
+        exit(1)
+    p.program.print()

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -4,9 +4,9 @@ from ..lexer import print_lex
 if __name__ == "__main__":
     sc = """
     iwf (1 == 2) [[
-        aqua-chan = 3~
+        aqua-sama = 3~
     ]] ewse iwf (4 == 5) [[
-        aqua-chan = 6~
+        aqua-senpai = 6~
     ]] ewse [[
         aqua-chan = 7~
     ]]

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -3,6 +3,7 @@ from ..lexer import print_lex
 
 if __name__ == "__main__":
     sc = """
+    gwobaw shion-chan = 5+6*7~
     iwf (1 == 2) [[
         aqua-sama = 3~
     ]] ewse iwf (4 == 5) [[

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -6,10 +6,26 @@ if __name__ == "__main__":
     gwobaw shion-chan = 5+6*7~
     iwf (1 == 2) [[
         aqua-sama = 3~
+        shion-sama = 3~
+        ojou-sama = 3~
     ]] ewse iwf (4 == 5) [[
-        aqua-senpai = 6~
+        aqua-sama = 6~
+        shion-sama = 6~
+        ojou-sama = 6~
+    ]] ewse iwf (7 == 8) [[
+        aqua-sama = 9~
+        shion-sama = 9~
+        ojou-sama = 9~
+    ]] ewse iwf (10 == 11) [[
+        aqua-sama = 12~
+        shion-sama = 12~
+        ojou-sama = 12~
     ]] ewse [[
-        aqua-chan = 7~
+        iwf (1 == 2) [[
+            sora-senpai = "nested!"~
+        ]] ewse [[
+            sora-senpai = "if statements!"~
+        ]]
     ]]
     """
     # >//<

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -126,6 +126,7 @@ class Parser:
         self.register_prefix(TokenType.OPEN_BRACE, self.parse_array)
         self.register_prefix(TokenType.STRING_PART_START, self.parse_string_parts)
         self.register_prefix(TokenType.OPEN_PAREN, self.parse_grouped_expressions)
+        self.register_prefix(TokenType.IWF, self.parse_if_statement)
 
         # literals (just returns curr_tok)
         self.register_prefix("IDENTIFIER", self.parse_ident)

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -81,9 +81,6 @@ class Parser:
         self.register_init()
 
         self.program = self.parse_program()
-        # print(self.program)
-        self.program.print()
-
 
     def advance(self, inc: int = 1):
         'advance the current and peek tokens based on the increment. default is 1'
@@ -176,7 +173,7 @@ class Parser:
                     p.classes.append(self.parse_class())
                 case TokenType.GWOBAW:
                     p.globals.append(self.parse_declaration())
-                case TokenType.TERMINATOR:
+                case TokenType.TERMINATOR | TokenType.DOUBLE_CLOSE_BRACKET:
                     self.advance()
                 case TokenType.IWF:
                     tmp = self.parse_if_statement()
@@ -290,18 +287,17 @@ class Parser:
     def parse_return_statement(self):
         'parse return statements'
         rs = ReturnStatement()
-        self.advance() # consume the return token
         if not self.expect_peek(TokenType.OPEN_PAREN):
             self.peek_error(TokenType.OPEN_PAREN)
             self.advance()
             return None
         self.advance() # consume the open paren
         rs.expr = self.parse_expression(LOWEST)
+
         if not self.expect_peek(TokenType.CLOSE_PAREN):
             self.advance()
             self.unclosed_paren_error(self.curr_tok)
             return None
-        self.advance() # consume the close paren
         if not self.expect_peek(TokenType.TERMINATOR):
             self.advance()
             self.unterminated_error(self.curr_tok)
@@ -399,7 +395,7 @@ class Parser:
         # is an assignment
         a = Assignment()
         a.id = ident
-        if not self.expect_peek(TokenType.EQUAL):
+        if not self.expect_peek(TokenType.ASSIGNMENT_OPERATOR):
             self.peek_error(self.peek_tok)
             self.advance()
             return None

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -298,6 +298,65 @@ class Parser:
     def parse_class(self):
         pass
     def parse_if_statement(self):
+        ie = IfExpression()
+        if not self.expect_peek(TokenType.OPEN_PAREN):
+            self.peek_error(TokenType.OPEN_PAREN)
+            self.advance()
+            return None
+        self.advance()
+        ie.condition = self.parse_expression(LOWEST)
+        if not self.expect_peek(TokenType.CLOSE_PAREN):
+            self.advance()
+            self.unclosed_paren_error(self.curr_tok)
+            return None
+        if not self.expect_peek(TokenType.DOUBLE_OPEN_BRACKET):
+            self.peek_error(TokenType.DOUBLE_OPEN_BRACKET)
+            self.advance()
+            return None
+        ie.then = self.parse_block_statement()
+        if not self.expect_peek(TokenType.DOUBLE_CLOSE_BRACKET):
+            self.advance()
+            self.unclosed_bracket_error(self.curr_tok)
+            return None
+
+        while self.expect_peek(TokenType.EWSE_IWF):
+            eie = ElseIfExpression()
+            self.advance()
+            if not self.expect_peek(TokenType.OPEN_PAREN):
+                self.peek_error(TokenType.OPEN_PAREN)
+                self.advance()
+                return None
+            self.advance()
+            eie.condition = self.parse_expression(LOWEST)
+            if not self.expect_peek(TokenType.CLOSE_PAREN):
+                self.advance()
+                self.unclosed_paren_error(self.curr_tok)
+                return None
+            if not self.expect_peek(TokenType.DOUBLE_OPEN_BRACKET):
+                self.peek_error(TokenType.DOUBLE_OPEN_BRACKET)
+                self.advance()
+                return None
+            eie.then = self.parse_block_statement()
+            if not self.expect_peek(TokenType.DOUBLE_CLOSE_BRACKET):
+                self.advance()
+                self.unclosed_bracket_error(self.curr_tok)
+                return None
+            ie.else_ifs.append(eie)
+
+        if self.expect_peek(TokenType.EWSE):
+            self.advance() # consume the ewse token
+            if not self.expect_peek(TokenType.DOUBLE_OPEN_BRACKET):
+                self.peek_error(TokenType.DOUBLE_OPEN_BRACKET)
+                self.advance()
+                return None
+            ie.else_block = self.parse_block_statement()
+            if not self.expect_peek(TokenType.DOUBLE_CLOSE_BRACKET):
+                self.advance()
+                self.unclosed_bracket_error(self.curr_tok)
+                return None
+        return ie
+
+    def parse_block_statement(self):
         pass
     def parse_while_statement(self):
         'this includes do while block statements'

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -35,7 +35,7 @@ class InfixExpression:
         self.op = None
         self.right = None
     def print(self, indent = 1):
-        return f"infix: {self.__str__()}"
+        print(f"infix: {self.__str__()}")
     def __str__(self):
         return f"({self.left} {self.op} {self.right})"
     def __len__(self):
@@ -126,6 +126,17 @@ class ArrayDeclaration:
         tmp = self.value
         compute_lengths(tmp, 0)
 
+class Assignment:
+    def __init__(self):
+        self.id = None
+        self.value = None
+    def print(self, indent = 1):
+        return f"assign: {self.__str__()}"
+    def __str__(self):
+        return f"{self.id} = {self.value}"
+    def __len__(self):
+        return 1
+
 class Declaration:
     def __init__(self):
         self.id = None
@@ -134,13 +145,15 @@ class Declaration:
         self.is_const: bool = False
 
     def print(self, indent = 1):
-        print(f"{INDENT(0)} declare: {self.id.print(indent)}")
-        print(f"{INDENT(indent)} type: {self.dtype.print(indent)}")
+        print(f"{INDENT(indent)} declare: ", end='')
+        self.id.print(indent)
+        print(f"{INDENT(indent)} type: ", end='')
+        self.dtype.print(indent)
         if self.value:
-            print(f"{INDENT(indent)} value: {self.value.print(indent)}")
+            print(f"{INDENT(indent)} value: ", end='')
+            self.value.print(indent)
         if self.is_const:
             print(f"{INDENT(indent)} constant")
-        return "|"
 
 class FnCall:
     def __init__(self):
@@ -162,16 +175,20 @@ class IfExpression:
         self.else_block = None
 
     def print(self, indent = 1):
-        print(f"{INDENT(indent)} if {self.condition.print(indent)}")
-        print(f"{INDENT(indent)} then:")
-        print(f"{self.then.print(indent+1)}")
+        print(f"{INDENT(indent)} if statement:")
+        print(f"{INDENT(indent+1)} condition: ", end='')
+        self.condition.print(indent)
+        print(f"{INDENT(indent+1)} then:")
+        self.then.print(indent+2)
         for e in self.else_if:
-            print(f"{INDENT(indent)} else if {e.condition.print(indent)}")
-            print(f"{INDENT(indent)} then:")
-            print(f"{e.then.print(indent+1)}")
+            print(f"{INDENT(indent+1)} else if statement:")
+            print(f"{INDENT(indent+2)} condition: ", end='')
+            e.condition.print(indent+2)
+            print(f"{INDENT(indent+2)} then:")
+            e.then.print(indent+2)
         if self.else_block:
-            print(f"{INDENT(indent)} else:")
-            print(f"{self.else_block.print(indent+1)}")
+            print(f"{INDENT(indent+1)} else:")
+            self.else_block.print(indent+2)
 
 class ElseIfExpression:
     def __init__(self):
@@ -183,12 +200,8 @@ class BlockStatement:
         self.statements = []
     def print(self, indent = 1):
         print(f"{INDENT(indent)} block:")
-        for i,s in enumerate(self.statements):
-            if i != len(self.statements) - 1:
-                print(f"{s.print(indent+1)}")
-            else:
-                return f"{s.print(indent+1)}"
-
+        for s in self.statements:
+            s.print(indent+1)
 
 class Function:
     def __init__(self):
@@ -215,7 +228,7 @@ class Program:
     def print(self, indent = 1):
         print("globals:")
         for g in self.globals:
-            print(g.print(1))
+            g.print(0)
         print("functions:")
         for fn in self.functions:
             print(f"{' ' * (indent*4)}{fn}")

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -159,7 +159,7 @@ class IfExpression:
         self.condition = None
         self.then = None
         self.else_if: list[ElseIfExpression] = []
-        self.else_ = None
+        self.else_block = None
 
     def print(self, indent = 1):
         print(f"{INDENT(indent)} if {self.condition.print(indent)}")
@@ -169,9 +169,9 @@ class IfExpression:
             print(f"{INDENT(indent)} else if {e.condition.print(indent)}")
             print(f"{INDENT(indent)} then:")
             print(f"{e.then.print(indent+1)}")
-        if self.else_:
+        if self.else_block:
             print(f"{INDENT(indent)} else:")
-            print(f"{self.else_.print(indent+1)}")
+            print(f"{self.else_block.print(indent+1)}")
 
 class ElseIfExpression:
     def __init__(self):

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -12,7 +12,7 @@ class ReturnStatement:
     def __init__(self):
         self.expr = None
     def print(self, indent = 1):
-        return f"return {self.__str__()}"
+        print(f"return {self.__str__()}")
     def __str__(self):
         return f"{self.expr}"
     def __len__(self):
@@ -23,7 +23,7 @@ class PrefixExpression:
         self.op = None
         self.right = None
     def print(self, indent = 1):
-        return f"prefix: {self.__str__()}"
+        print(f"prefix: {self.__str__()}")
     def __str__(self):
         return f"({self.op} {self.right})"
     def __len__(self):
@@ -46,7 +46,7 @@ class PostfixExpression:
         self.left = None
         self.op = None
     def print(self, indent = 1):
-        return f"postfix: {self.__str__()}"
+        print(f"postfix: {self.__str__()}")
     def __str__(self):
         return f"{self.left} {self.op}"
     def __len__(self):
@@ -59,7 +59,7 @@ class StringFmt:
         self.exprs = []
         self.end = None
     def print(self, indent = 1):
-        return f"string fmt: {self.__str__()}"
+        print(f"string fmt: {self.__str__()}")
     def __str__(self):
         return f"{self.start}{''.join([f'{m}{e}' for m,e in zip(self.mid, self.exprs)])}{self.end}"
     def __len__(self):
@@ -69,7 +69,7 @@ class ArrayLiteral:
     def __init__(self):
         self.elements = []
     def print(self, indent = 1):
-        return f"{INDENT(indent)} array: {self.__str__()}"
+        print(f"{INDENT(indent)} array: {self.__str__()}")
     def __str__(self):
         return f"[{', '.join([str(e) for e in self.elements])}]"
     def __len__(self):
@@ -88,8 +88,10 @@ class ArrayDeclaration:
         self.is_const: bool = False
 
     def print(self, indent = 1):
-        print(f"{INDENT(0)} declare: {self.id.print(indent)}")
-        print(f"{INDENT(indent)} type: {self.dtype.print(indent)}")
+        print(f"{INDENT(indent)} declare array: ", end='')
+        self.id.print(indent)
+        print(f"{INDENT(indent)} type: ", end='')
+        self.dtype.print(indent)
         if self.is_const:
             print(f"{INDENT(indent)} constant")
         if self.dimension:
@@ -97,15 +99,15 @@ class ArrayDeclaration:
         if self.size:
             print(f"{INDENT(indent)} size:")
             for s in self.size:
-                print(f"{INDENT(indent+1)} {s.print(indent+1)}")
+                print(f"{INDENT(indent+1)} ", end='')
+                s.print(indent+1)
         if self.value:
             print(f"{INDENT(indent)} value:")
-            print(f"{self.value.print(indent+1)}")
+            self.value.print(indent+1)
         if self.length:
             print(f"{INDENT(indent)} length:")
             for l in self.length:
                 print(f"{INDENT(indent+1)} {l}")
-        return "|"
 
     def compute_len(self):
         def compute_lengths(array, depth):
@@ -131,7 +133,7 @@ class Assignment:
         self.id = None
         self.value = None
     def print(self, indent = 1):
-        return f"assign: {self.__str__()}"
+        print(f"assign: {self.__str__()}")
     def __str__(self):
         return f"{self.id} = {self.value}"
     def __len__(self):
@@ -161,7 +163,7 @@ class FnCall:
         self.args = []
 
     def print(self, _ = 1):
-        return f"call: {self.__str__()}"
+        print(f"call: {self.__str__()}")
     def __str__(self):
         return f"{self.id}({', '.join([str(a) for a in self.args])})"
     def __len__(self):

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -154,6 +154,42 @@ class FnCall:
     def __len__(self):
         return 1
 
+class IfExpression:
+    def __init__(self):
+        self.condition = None
+        self.then = None
+        self.else_if: list[ElseIfExpression] = []
+        self.else_ = None
+
+    def print(self, indent = 1):
+        print(f"{INDENT(indent)} if {self.condition.print(indent)}")
+        print(f"{INDENT(indent)} then:")
+        print(f"{self.then.print(indent+1)}")
+        for e in self.else_if:
+            print(f"{INDENT(indent)} else if {e.condition.print(indent)}")
+            print(f"{INDENT(indent)} then:")
+            print(f"{e.then.print(indent+1)}")
+        if self.else_:
+            print(f"{INDENT(indent)} else:")
+            print(f"{self.else_.print(indent+1)}")
+
+class ElseIfExpression:
+    def __init__(self):
+        self.condition = None
+        self.then = None
+
+class BlockStatement:
+    def __init__(self):
+        self.statements = []
+    def print(self, indent = 1):
+        print(f"{INDENT(indent)} block:")
+        for i,s in enumerate(self.statements):
+            if i != len(self.statements) - 1:
+                print(f"{s.print(indent+1)}")
+            else:
+                return f"{s.print(indent+1)}"
+
+
 class Function:
     def __init__(self):
         self.id = None

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -9,7 +9,7 @@ class ReturnStatement:
     def __init__(self):
         self.expr = None
     def print(self, indent = 1):
-        print(f"return {self.__str__()}")
+        print(f"{INDENT(indent)} return {self.__str__()}")
     def __str__(self):
         return f"{self.expr}"
     def __len__(self):
@@ -130,7 +130,10 @@ class Assignment:
         self.id = None
         self.value = None
     def print(self, indent = 1):
-        print(f"assign: {self.__str__()}")
+        print(f"{INDENT(indent)} assign: ", end='')
+        self.id.print(indent)
+        print(f"{INDENT(indent+1)} value: ", end='')
+        self.value.print(indent)
     def __str__(self):
         return f"{self.id} = {self.value}"
     def __len__(self):

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -3,10 +3,7 @@ All productions must have an __str__() method
 '''
 
 def INDENT(n=0) -> str:
-    result = "|"
-    for _ in range(n):
-        result += "  " + "|"
-    return result + "__"
+    return "    " * n
 
 class ReturnStatement:
     def __init__(self):
@@ -149,13 +146,13 @@ class Declaration:
     def print(self, indent = 1):
         print(f"{INDENT(indent)} declare: ", end='')
         self.id.print(indent)
-        print(f"{INDENT(indent)} type: ", end='')
-        self.dtype.print(indent)
+        print(f"{INDENT(indent+1)} type: ", end='')
+        self.dtype.print(indent+1)
         if self.value:
-            print(f"{INDENT(indent)} value: ", end='')
-            self.value.print(indent)
+            print(f"{INDENT(indent+1)} value: ", end='')
+            self.value.print(indent+1)
         if self.is_const:
-            print(f"{INDENT(indent)} constant")
+            print(f"{INDENT(indent+1)} constant")
 
 class FnCall:
     def __init__(self):
@@ -182,6 +179,7 @@ class IfExpression:
         self.condition.print(indent)
         print(f"{INDENT(indent+1)} then:")
         self.then.print(indent+2)
+        print(f"{INDENT(indent+1)}")
         for e in self.else_if:
             print(f"{INDENT(indent+1)} else if statement:")
             print(f"{INDENT(indent+2)} condition: ", end='')
@@ -228,12 +226,15 @@ class Program:
         self.classes: list = []
 
     def print(self, indent = 1):
-        print("globals:")
+        print("GLOBALS:")
         for g in self.globals:
-            g.print(0)
-        print("functions:")
+            g.print(1)
+            print()
+        print("\nFUNCTIONS:")
         for fn in self.functions:
             print(f"{' ' * (indent*4)}{fn}")
-        print("classes:")
+            print()
+        print("\nCLASSES:")
         for c in self.classes:
             print(f"{' ' * (indent*4)}{c}")
+            print()


### PR DESCRIPTION
### changes
- parsing declarations now take an optional arg `ident` which may come from other parsers. the old behavior of starting with expecting an identifier in the `peek_tok` position still remains as long as `ident` is `None`
- there's another dict of parsing fns, `in_block_parsing_fns` which are parsers for certain token types inside a block statement
- printing productions actually prints now, and does not return a string (or None)

### new
- parse if else statements
- parse block statements
- parse assignment statements

### etc
- fixed parsing return statement
- AST printing does not make use of `|` and `_` anymore, just whitespaces ` `