### PR TITLE
parse_ident_statement fix

### DIFF
--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -535,7 +535,7 @@ class Parser:
             # Consume open paren
             fc = FnCall()
             fc.id = ident
-            fc.in_expr = True
+            fc.in_expr = False
 
             self.advance(2)
             stop_conditions = [TokenType.CLOSE_PAREN, TokenType.TERMINATOR, TokenType.EOF]
@@ -809,6 +809,7 @@ class Parser:
 
         fc = FnCall()
         fc.id = self.curr_tok
+        fc.in_expr = True
         self.advance(2)
         stop_conditions = [TokenType.CLOSE_PAREN, TokenType.TERMINATOR, TokenType.EOF]
         while not self.curr_tok_is_in(stop_conditions):

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -82,11 +82,13 @@ class FnCall:
     def __init__(self):
         self.id = None
         self.args = []
+        self.in_expr = False    # For determining indent in printing
 
-    def string(self, _ = 1):
+    def string(self, indent = 1):
+        i = indent if self.in_expr else 0
         return sprintln("call:", self.id.string(), 
                         f'({", ".join([a.string() for a in self.args])})', 
-                        indent=0)
+                        indent=i)
     def __len__(self):
         return 1
 
@@ -133,6 +135,12 @@ class ArrayDeclaration:
                     compute_lengths(elem, depth + 1)
 
         compute_lengths(self.value, 0)
+
+class UselessIdStatement:
+    def __init__(self):
+        self.id = None
+    def string(self, indent = 0):
+        return sprintln("id:", self.id.string(), indent=indent)
 
 class Assignment:
     def __init__(self):

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -85,7 +85,7 @@ class FnCall:
         self.in_expr = False    # For determining indent in printing
 
     def string(self, indent = 1):
-        i = indent if self.in_expr else 0
+        i = 0 if self.in_expr else indent
         return sprintln("call:", self.id.string(), 
                         f'({", ".join([a.string() for a in self.args])})', 
                         indent=i)

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -85,10 +85,14 @@ class FnCall:
         self.in_expr = False    # For determining indent in printing
 
     def string(self, indent = 1):
-        i = 0 if self.in_expr else indent
-        return sprintln("call:", self.id.string(), 
-                        f'({", ".join([a.string() for a in self.args])})', 
-                        indent=i)
+        if self.in_expr:
+            return sprint("call:", self.id.string(),
+                            f'({", ".join([a.string() for a in self.args])})',
+                            indent=0)
+        else:
+            return sprintln("call:", self.id.string(),
+                          f'({", ".join([a.string() for a in self.args])})',
+                          indent=indent)
     def __len__(self):
         return 1
 


### PR DESCRIPTION
### Added:
- new production for useless id statement (`aqua~`)
- parsing for useless id statements
- parsing for function calls outside expressions (id_statements)

### Changes:
- added dynamic identing to function calls
- `if fn call is in expr: indent = 0`
- `if fn call is used as an id statement: indent=indent`

### Preview:
- useless id statements look like this:
![image](https://github.com/Gidsss/UwUIDE/assets/66175571/88e0e181-839f-49ae-9df1-7e7a017ec5d2)
- function calls as id statements look like this:
![image](https://github.com/Gidsss/UwUIDE/assets/66175571/3cd780a9-da99-4ee6-a443-e0f452379b1e)
- function calls in expressions still get printed correctly 👍👍:
![image](https://github.com/Gidsss/UwUIDE/assets/66175571/2f0f6189-4823-45e7-8d2f-5f6e2a5f80ae)


