### PR TITLE
Feat/tree APIs

### DIFF
--- a/src/lexer/token.py
+++ b/src/lexer/token.py
@@ -24,6 +24,8 @@ class TokenType(Enum):
         return self.token
     def string(self, _ = 1):
         return self.__str__()
+    def header(self):
+        return self.token
 
     def __format__(self, format_spec):
         return str.__format__(str(self), format_spec)
@@ -170,6 +172,8 @@ class Token:
     def __str__(self):
         return self._lexeme
     def string(self, _ = 1):
+        return self._lexeme
+    def header(self):
         return self._lexeme
 
 

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -5,48 +5,29 @@ from .error_handler import ErrorSrc
 
 if __name__ == "__main__":
     sc = """
-    gwobaw wetuwn 10~
     fwunc mainuwu-san() [[
-        iwf () [[
-            a-san = 20~
+        iwf (fax) [[
+            a-san[] = 20~
+        ]] ewse iwf (4 == 5) [[
+            aqua-sama = 6~
+            shion-sama = 6~
+            ojou-sama = 6~
+        ]] ewse iwf (7 == 8) [[
+            aqua-sama = 9~
+            shion-sama = 9~
+            ojou-sama = 9~
+        ]] ewse iwf (10 == 11) [[
+            aqua-sama = 12~
+            shion-sama = 12~
+            ojou-sama = 12~
+        ]] ewse [[
+            iwf (1 == 2) [[
+                sora-senpai = "nested!"~
+            ]] ewse [[
+                sora-senpai = "if statements!"~
+            ]]
         ]]
     ]]
-    """
-#     ewse iwf (4 == 5) [[
-#         aqua-sama = 6~
-#             shion-sama = 6~
-#             ojou-sama = 6~
-#     ]] ewse iwf (7 == 8) [[
-#             aqua-sama = 9~
-#                 shion-sama = 9~
-#                 ojou-sama = 9~
-#         ]] ewse iwf (10 == 11) [[
-#         aqua-sama = 12~
-#             shion-sama = 12~
-#             ojou-sama = 12~
-#     ]] ewse [[
-#     iwf (1 == 2) [[
-#         sora-senpai = "nested!"~
-#     ]] ewse [[
-#             sora-senpai = "if statements!"~
-#         ]]
-# ]]
-    sc = """
-    gwobaw aqua-chan[] = { {
-            {
-                (2+2)*2,
-            }
-        },
-        {
-            3+3*3,
-            (4+4)*4,
-        },
-        1,
-    }~
-    gwobaw ojou-chan = shion(1, 2, aqua(3+4*5), lap("hello |-name--| world"))~
-    gwobaw shion-chan = 1+- (1-2) -- == 5 -3-- *-5 ~
-    gwobaw lap-chan[]-dono = {1,2,3,4,5,6,7,8,9,10}~
-    gwobaw suba-chan[] = {2+2, (3+3)*3}~
     """
 
     source: list[str] = [line if line else '\n' for line in sc.split("\n")]

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -73,13 +73,13 @@ if __name__ == "__main__":
     print("--- Printing Whole Program ---")
     print(p.program)
     print("\n--- Printing only Main Function ---")
-    print(p.program.main())
+    print(p.program.mainuwu_string())
     print("\n--- Printing only Global Declarations ---")
-    print(p.program.globs())
+    print(p.program.globals_string())
     print("\n--- Printing only Functions ---")
-    print(p.program.funcs())
+    print(p.program.functions_string())
     print("\n--- Printing only Classes ---")
-    print(p.program._classes())
+    print(p.program.classes_string())
 
     if p.errors:
         exit(1)

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -196,8 +196,7 @@ class Parser:
                     self.advance()
 
         if p.mainuwu is None:
-            self.missing_mainuwu(self.curr_tok)
-            return None
+            self.missing_mainuwu()
 
         return p
 

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -75,7 +75,7 @@ class Parser:
         self.register_init()
 
         if not self.tokens:
-            self.missing_mainuwu(Token("EOF", TokenType.EOF, (0, 0), (0, 0)))
+            self.missing_mainuwu_error(Token("EOF", TokenType.EOF, (0, 0), (0, 0)))
             self.program = None
             return
 
@@ -179,7 +179,7 @@ class Parser:
                 case TokenType.FWUNC:
                     if self.peek_tok_is(TokenType.MAINUWU):
                         if p.mainuwu is not None:
-                            self.multiple_mainuwu(self.peek_tok)
+                            self.multiple_mainuwu_error(self.peek_tok)
                             self.advance(2)
                         else:
                             p.mainuwu = self.parse_function(main=True)
@@ -196,7 +196,7 @@ class Parser:
                     self.advance()
 
         if p.mainuwu is None:
-            self.missing_mainuwu()
+            self.missing_mainuwu_error(self.curr_tok)
 
         return p
 
@@ -323,7 +323,7 @@ class Parser:
 
         if main:
             if not self.expect_peek(TokenType.SAN):
-                self.invalid_mainuwu_rtype(self.peek_tok)
+                self.invalid_mainuwu_rtype_error(self.peek_tok)
                 self.advance(2)
                 return None
         else:
@@ -405,7 +405,7 @@ class Parser:
         if not self.expect_peek(TokenType.CLOSE_PAREN):
             # If parameters are for main function, raise error immediately cuz it can't have params
             if main:
-                self.invalid_mainuwu_params(self.peek_tok)
+                self.invalid_mainuwu_params_error(self.peek_tok)
                 self.advance()
                 return None
 
@@ -455,7 +455,7 @@ class Parser:
                 elif self.expect_peek(TokenType.CLOSE_PAREN):
                     break
                 else:
-                    self.invalid_parameter(self.peek_tok)
+                    self.invalid_parameter_error(self.peek_tok)
                     self.advance(2)
                     return None
 
@@ -470,7 +470,7 @@ class Parser:
 
         # Check if condition is empty
         if self.peek_tok_is(TokenType.CLOSE_PAREN):
-            self.empty_condition()
+            self.empty_condition_error()
             self.advance()
             ie.condition = None
         else:
@@ -532,7 +532,7 @@ class Parser:
 
         # Check if block is empty
         if self.peek_tok_is(TokenType.DOUBLE_CLOSE_BRACKET):
-            self.empty_code_body()
+            self.empty_code_body_error()
             return None
 
         self.advance()  # consume the open bracket
@@ -618,7 +618,7 @@ class Parser:
 
         # Check if condition is empty
         if self.peek_tok_is(TokenType.CLOSE_PAREN):
-            self.empty_condition()
+            self.empty_condition_error()
             self.advance()
             wl.condition = None
         else:
@@ -1008,7 +1008,6 @@ class Parser:
             self.peek_tok.position,
             self.peek_tok.end_position
         ))
-        # self.errors.append(f"expected next token to be '{token}', got '{self.peek_tok}' instead")
     def no_prefix_parse_fn_error(self, token_type):
         self.errors.append(Error(
             "MISSING PREFIX PARSING FUNCTION",
@@ -1016,7 +1015,6 @@ class Parser:
             self.curr_tok.position,
             self.curr_tok.end_position
         ))
-        # self.errors.append(f"no prefix parsing function found for {token_type}")
     def no_in_block_parse_fn_error(self, token_type):
         self.errors.append(Error(
             "MISSING IN-BLOCK PARSING FUNCTION",
@@ -1024,7 +1022,6 @@ class Parser:
             self.curr_tok.position,
             self.curr_tok.end_position
         ))
-        # self.errors.append(f"no parsing function found for {token_type} inside block statements")
     def invalid_global_declaration_error(self, token: Token):
         self.errors.append(Error(
             "INVALID GLOBAL DECLARATION",
@@ -1032,7 +1029,6 @@ class Parser:
             token.position,
             token.end_position
         ))
-        # self.errors.append(f"Expected global function/class/variable/constant declaration, got {token.lexeme}")
     def no_ident_in_declaration_error(self, token: Token):
         self.errors.append(Error(
             "MISSING IDENTIFIER",
@@ -1040,7 +1036,6 @@ class Parser:
             token.position,
             token.end_position
         ))
-        # self.errors.append(f"Expected identifier in declaration, got {token.lexeme}")
     def no_ident_in_class_declaration_error(self, token: Token):
         self.errors.append(Error(
             "MISSING IDENTIFIER",
@@ -1048,7 +1043,6 @@ class Parser:
             token.position,
             token.end_position
         ))
-        # self.errors.append(f"Expected identifier in class declaration, got {token.lexeme}")
     def no_ident_in_func_declaration_error(self, token: Token):
         self.errors.append(Error(
             "MISSING IDENTIFIER",
@@ -1056,7 +1050,6 @@ class Parser:
             token.position,
             token.end_position
         ))
-        # self.errors.append(f"Expected identifier in function declaration, got {token.lexeme}")
     def no_ident_in_param_error(self, token: Token):
         self.errors.append(Error(
             "MISSING IDENTIFIER",
@@ -1064,7 +1057,6 @@ class Parser:
             token.position,
             token.end_position
         ))
-        # self.errors.append(f"Expected identifier in parameter, got {token.lexeme}")
     def no_data_type_indicator_error(self, token: Token):
         self.errors.append(Error(
             "MISSING DASH DATA TYPE",
@@ -1072,7 +1064,6 @@ class Parser:
             token.position,
             token.end_position
         ))
-        # self.errors.append(f"Expected dash before data type, got {token.lexeme}")
     def no_data_type_error(self, token: Token):
         self.errors.append(Error(
             "MISSING DATA TYPE",
@@ -1080,7 +1071,6 @@ class Parser:
             token.position,
             token.end_position
         ))
-        # self.errors.append(f"Expected data type, got {token.lexeme}")
     def no_dono_error(self, token: Token):
         self.errors.append(Error(
             "MISSING DONO",
@@ -1088,15 +1078,13 @@ class Parser:
             token.position,
             token.end_position
         ))
-        # self.errors.append(f"Expected 'dono' to denote variable as constant instead, got {token.lexeme}")
-    def invalid_parameter(self, token: Token):
+    def invalid_parameter_error(self, token: Token):
         self.errors.append(Error(
             "INVALID PARAMETER",
             f"Invalid parameter. Expected ',' or ')', got {token.lexeme}.",
             token.position,
             token.end_position
         ))
-        # self.errors.append(f"Invalid parameter. Expected ',' or ')', got {token.lexeme}")
     def unterminated_error(self, token: Token):
         self.errors.append(Error(
             "UNTERMINATED STATEMENT",
@@ -1104,7 +1092,6 @@ class Parser:
             token.position,
             token.end_position
         ))
-        # self.errors.append(f"Expected '~' to terminate the statement, got {token.lexeme}")
     def unclosed_paren_error(self, token: Token):
         self.errors.append(Error(
             "UNCLOSED PARENTHESIS",
@@ -1112,7 +1099,6 @@ class Parser:
             token.position,
             token.end_position
         ))
-        # self.errors.append(f"Expected ')' to close the parenthesis, got {token.lexeme}")
     def unclosed_double_bracket_error(self, token: Token):
         self.errors.append(Error(
             "UNCLOSED DOUBLE BRACKET",
@@ -1120,7 +1106,6 @@ class Parser:
             token.position,
             token.end_position
         ))
-        # self.errors.append(f"Expected '}}' to close the double bracket, got {token.lexeme}")
     def unclosed_bracket_error(self, token: Token):
         self.errors.append(Error(
             "UNCLOSED BRACKET",
@@ -1128,7 +1113,6 @@ class Parser:
             token.position,
             token.end_position
         ))
-        # self.errors.append(f"Expected ']' to close the bracket, got {token.lexeme}")
     def unclosed_brace_error(self, token: Token):
         self.errors.append(Error(
             "UNCLOSED BRACE",
@@ -1136,23 +1120,20 @@ class Parser:
             token.position,
             token.end_position
         ))
-        # self.errors.append(f"Expected '}}' to close the brace, got {token.lexeme}")
-    def empty_condition(self):
+    def empty_condition_error(self):
         self.errors.append(Error(
             "EMPTY CONDITION",
             f"Conditions cannot be empty.",
             self.curr_tok.position,
             self.curr_tok.end_position
         ))
-        # self.errors.append(f"Conditions cannot be empty")
-    def empty_code_body(self):
+    def empty_code_body_error(self):
         self.errors.append(Error(
             "EMPTY CODE BODY",
             f"Code bodies must contain at least one or more statement.",
             self.curr_tok.position,
             self.curr_tok.end_position
         ))
-        # self.errors.append(f"Code bodies must have at least one or more statement")
     def uninitialized_assignment_error(self, token: Token):
         self.errors.append(Error(
             "MISSING VALUE ASSIGNMENT",
@@ -1160,7 +1141,6 @@ class Parser:
             token.position,
             token.end_position
         ))
-        # self.errors.append(f"Assignments must have a value after '='. got '{token.lexeme}'")
     def unclosed_string_part_error(self, string_start, token: Token):
         self.errors.append(Error(
             "UNCLOSED FORMAT STRING",
@@ -1168,29 +1148,28 @@ class Parser:
             token.position,
             token.end_position
         ))
-        # self.errors.append(f"Unclosed string part. Expected '{string_start.lexeme[:-1]}|' to be closed by something like '|string part end\"'. got '{token.lexeme}'")
-    def invalid_mainuwu_rtype(self, token: Token):
+    def invalid_mainuwu_rtype_error(self, token: Token):
         self.errors.append(Error(
             "INVALID MAINUWU FUNCTION",
             f"The mainuwu function's return type must only be 'san', got '{token}'.",
             token.position,
             token.end_position
         ))
-    def invalid_mainuwu_params(self, token: Token):
+    def invalid_mainuwu_params_error(self, token: Token):
         self.errors.append(Error(
             "INVALID MAINUWU FUNCTION",
             f"Expected ')', got '{token}'.\n\tThe mainuwu function cannot accept any parameters.",
             token.position,
             token.end_position
         ))
-    def multiple_mainuwu(self, token: Token):
+    def multiple_mainuwu_error(self, token: Token):
         self.errors.append(Error(
             "MULTIPLE MAINUWU FUNCTION",
             f"The program must only have one mainuwu function.",
             token.position,
             token.end_position
         ))
-    def missing_mainuwu(self, token: Token):
+    def missing_mainuwu_error(self, token: Token):
         self.errors.append(Error(
             "MISSING MAINUWU FUNCTION",
             f"The program must have at least one mainuwu function.",

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -14,6 +14,7 @@ class PrefixExpression:
     def __init__(self):
         self.op = None
         self.right = None
+        self.folded = False
 
     def string(self, _ = 1):
         return sprint(self.op.string(), self.right.string(), indent=0)
@@ -25,6 +26,7 @@ class InfixExpression:
         self.left = None
         self.op = None
         self.right = None
+        self.folded = False
 
     def string(self, _ = 1):
         return sprint(f'({self.left.string()} {self.op.string()} {self.right.string()})', indent=0)
@@ -35,6 +37,7 @@ class PostfixExpression:
     def __init__(self):
         self.left = None
         self.op = None
+        self.folded = False
 
     def string(self, _ = 1):
         return sprint(self.left.string(), self.op.string(), indent=0)
@@ -48,6 +51,7 @@ class StringFmt:
         self.mid = []
         self.exprs = []
         self.end = None
+        self.folded = False
 
     def string(self, indent = 0):
         res = sprintln("string fmt:", indent=0)
@@ -68,6 +72,8 @@ class StringFmt:
 class ArrayLiteral:
     def __init__(self):
         self.elements = []
+        self.folded = False
+
     def string(self, indent = 0):
         res = sprintln("array literal:", indent=0)
         for e in self.elements:
@@ -83,6 +89,7 @@ class FnCall:
         self.id = None
         self.args = []
         self.in_expr = False    # For determining indent in printing
+        self.folded = False
 
     def string(self, indent = 1):
         if self.in_expr:
@@ -100,6 +107,7 @@ class FnCall:
 class ReturnStatement:
     def __init__(self):
         self.expr = None
+        self.folded = False
 
     def string(self, indent = 0):
         return sprintln("return", self.expr.string(indent), indent=indent)
@@ -112,6 +120,7 @@ class ArrayDeclaration:
         self.dtype = None
         self.value = None
         self.is_const: bool = False
+        self.folded = False
 
     def string(self, indent = 0):
         res = sprintln("declare array:", self.id.string(), indent=indent)
@@ -143,6 +152,8 @@ class ArrayDeclaration:
 class UselessIdStatement:
     def __init__(self):
         self.id = None
+        self.folded = False
+
     def string(self, indent = 0):
         return sprintln("id:", self.id.string(), indent=indent)
 
@@ -150,6 +161,8 @@ class Assignment:
     def __init__(self):
         self.id = None
         self.value = None
+        self.folded = False
+
     def string(self, indent = 0):
         res = sprintln("assign:", self.id.string(), indent=indent)
         res += sprintln("value:", self.value.string(), indent=indent+1)
@@ -163,6 +176,7 @@ class Declaration:
         self.dtype = None
         self.value = None
         self.is_const: bool = False
+        self.folded = False
 
     def string(self, indent = 0):
         res = sprintln("declare:", self.id.string(), indent=indent)
@@ -176,6 +190,8 @@ class Declaration:
 class Print:
     def __init__(self):
         self.values = []
+        self.folded = False
+
     def string(self, indent = 0):
         res = sprintln("print:", indent=indent)
         for v in self.values:
@@ -185,6 +201,8 @@ class Print:
 class Input:
     def __init__(self):
         self.value = None
+        self.folded = False
+
     def string(self, indent = 0):
         return sprintln("input:", self.value.string(), indent=indent)
     def print(self, indent = 0):
@@ -195,6 +213,7 @@ class Parameter:
     def __init__(self):
         self.id = None
         self.dtype = None
+        self.folded = False
 
     def string(self, indent = 0):
         res = sprintln("param:", self.id.string(), indent=0)
@@ -208,6 +227,7 @@ class IfStatement:
         self.then = None
         self.else_if: list[ElseIfStatement] = []
         self.else_block = None
+        self.folded = False
 
     def string(self, indent = 0):
         res = sprintln("if statement:", indent=indent)
@@ -225,6 +245,8 @@ class ElseIfStatement:
     def __init__(self):
         self.condition = None
         self.then = None
+        self.folded = False
+
     def string(self, indent = 0):
         res = sprintln("else if statement:", indent=indent)
         res += sprintln("condition:", self.condition.string(), indent=indent+1)
@@ -237,6 +259,8 @@ class WhileLoop:
         self.condition = None
         self.body = None
         self.is_do = False
+        self.folded = False
+
     def string(self, indent = 0):
         res = sprintln(f"{f'do' if self.is_do else ''} while statement:", indent=indent)
         res += sprintln("condition:", self.condition.string(), indent=indent+1)
@@ -250,6 +274,8 @@ class ForLoop:
         self.condition = None
         self.update = None
         self.body = None
+        self.folded = False
+
     def string(self, indent = 0):
         res = sprintln("for statement:", indent=indent)
         res += sprintln("init:", self.init.string(), indent=indent+1)
@@ -265,6 +291,7 @@ class Function:
         self.rtype = None
         self.params: list[Parameter] = []
         self.body = None
+        self.folded = False
 
     def string(self, indent = 0):
         res = sprintln("function:", self.id.string(), indent=indent)
@@ -286,6 +313,8 @@ class Class:
         self.body: list = []
         self.properties: list = []
         self.methods: list = []
+        self.folded = False
+
     def string(self, indent = 0):
         res = sprintln("class:", self.id.string(), indent=indent)
         if self.params:
@@ -308,6 +337,8 @@ class Class:
 class BlockStatement:
     def __init__(self):
         self.statements = []
+        self.folded = False
+
     def string(self, indent = 0):
         res = sprintln("block:", indent=indent)
         for s in self.statements:

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -1,19 +1,15 @@
 from src.lexer import Token
 '''
-All productions must have these properties:
-1. folded: bool
-
 All productions must have these methods:
 1. string(self, indent = 0)
-2. toggle_fold(self)
 
-3. header(self) -> str
+2. header(self) -> str
     - returns the string representation of the production
     - it can be a title or the value of the production itself
     - titles are for class productions
     - values are for atomic productions
 
-4. child_nodes(self) -> None | list[production classes]
+3. child_nodes(self) -> None | list[production classes]
     - returns None if atomic (aka leaf)
         - the value of the atomic production is in the header() method
     - returns a list of other production classes if not
@@ -31,10 +27,7 @@ class PrefixExpression:
     def __init__(self):
         self.op = None
         self.right = None
-        self.folded = False
 
-    def toggle_fold(self):
-        self.folded = not self.folded
     def header(self):
         return self.string()
     def child_nodes(self) -> None | list:
@@ -50,10 +43,6 @@ class InfixExpression:
         self.left = None
         self.op = None
         self.right = None
-        self.folded = False
-
-    def toggle_fold(self):
-        self.folded = not self.folded
     def header(self):
         return self.string()
     def child_nodes(self) -> None | list:
@@ -68,10 +57,6 @@ class PostfixExpression:
     def __init__(self):
         self.left = None
         self.op = None
-        self.folded = False
-
-    def toggle_fold(self):
-        self.folded = not self.folded
     def header(self):
         return self.string()
     def child_nodes(self) -> None | list:
@@ -89,10 +74,7 @@ class StringFmt:
         self.mid = []
         self.exprs = []
         self.end = None
-        self.folded = False
 
-    def toggle_fold(self):
-        self.folded = not self.folded
     def header(self):
         return "string fmt:"
     def child_nodes(self) -> None | list:
@@ -126,17 +108,10 @@ class StringFmt:
 class ArrayLiteral:
     def __init__(self):
         self.elements = []
-        self.folded = False
 
-    def toggle_fold(self):
-        self.folded = not self.folded
     def header(self):
-        if self.folded:
-            return "array literal ..."
         return "array literal:"
     def child_nodes(self) -> None | list:
-        if self.folded:
-            return None
         return self.elements
 
     def string(self, indent = 0):
@@ -154,10 +129,7 @@ class FnCall:
         self.id = None
         self.args = []
         self.in_expr = False    # For determining indent in printing
-        self.folded = False
 
-    def toggle_fold(self):
-        self.folded = not self.folded
     def header(self):
         if self.in_expr:
             return sprint(self.id.string(),
@@ -166,6 +138,7 @@ class FnCall:
         return sprint("call:", self.id.string(),
                         f'({", ".join([a.string() for a in self.args])})',
                         indent=0)
+
     def child_nodes(self) -> None | list:
         return None
 
@@ -185,10 +158,7 @@ class FnCall:
 class ReturnStatement:
     def __init__(self):
         self.expr = None
-        self.folded = False
 
-    def toggle_fold(self):
-        self.folded = not self.folded
     def header(self):
         return self.string()
     def child_nodes(self) -> None | list:
@@ -205,17 +175,10 @@ class ArrayDeclaration:
         self.dtype = None
         self.value = None
         self.is_const: bool = False
-        self.folded = False
 
-    def toggle_fold(self):
-        self.folded = not self.folded
     def header(self):
-        if self.folded:
-            return f"declare array: {self.id.string()} ..."
         return f"declare array: {self.id.string()}"
     def child_nodes(self) -> None | list:
-        if self.folded:
-            return None
         return [self.dtype, self.value, self.is_const]
 
     def string(self, indent = 0):
@@ -248,10 +211,7 @@ class ArrayDeclaration:
 class UselessIdStatement:
     def __init__(self):
         self.id: Token = None
-        self.folded = False
 
-    def toggle_fold(self):
-        self.folded = not self.folded
     def header(self):
         return self.string()
     def child_nodes(self) -> None | list:
@@ -264,15 +224,10 @@ class Assignment:
     def __init__(self):
         self.id: Token = None
         self.value = None
-        self.folded = False
 
-    def toggle_fold(self):
-        self.folded = not self.folded
     def header(self):
         return f"assign: {self.id.string()}"
     def child_nodes(self) -> None | list:
-        if self.folded:
-            return None
         return [self.value]
 
     def string(self, indent = 0):
@@ -288,17 +243,10 @@ class Declaration:
         self.dtype = None
         self.value = None
         self.is_const: bool = False
-        self.folded = False
 
-    def toggle_fold(self):
-        self.folded = not self.folded
     def header(self):
-        if self.folded:
-            return f"declare: {self.id.string()} ..."
         return f"declare: {self.id.string()}"
     def child_nodes(self) -> None | list:
-        if self.folded:
-            return None
         return [self.dtype, self.value, self.is_const]
 
     def string(self, indent = 0):
@@ -313,13 +261,8 @@ class Declaration:
 class Print:
     def __init__(self):
         self.values = []
-        self.folded = False
 
-    def toggle_fold(self):
-        self.folded = not self.folded
     def header(self):
-        if self.folded:
-            return "print: ..."
         return "print"
     def child_nodes(self) -> None | list:
         return self.values
@@ -333,13 +276,8 @@ class Print:
 class Input:
     def __init__(self):
         self.value = None
-        self.folded = False
 
-    def toggle_fold(self):
-        self.folded = not self.folded
     def header(self):
-        if self.folded:
-            return "input: ..."
         return "input"
     def child_nodes(self) -> None | list:
         return [self.value]
@@ -354,10 +292,7 @@ class Parameter:
     def __init__(self):
         self.id = None
         self.dtype = None
-        self.folded = False
 
-    def toggle_fold(self):
-        self.folded = not self.folded
     def header(self):
         return f"param: id: {self.id.string()} dtype: {self.dtype.string()}"
     def child_nodes(self) -> None | list:
@@ -375,17 +310,10 @@ class IfStatement:
         self.then = None
         self.else_if: list[ElseIfStatement] = []
         self.else_block = None
-        self.folded = False
 
-    def toggle_fold(self):
-        self.folded = not self.folded
     def header(self):
-        if self.folded:
-            return "if statement: ..."
         return "if statement:"
     def child_nodes(self) -> None | list:
-        if self.folded:
-            return None
         return [self.condition, self.then, self.else_if, self.else_block]
 
     def string(self, indent = 0):
@@ -404,17 +332,10 @@ class ElseIfStatement:
     def __init__(self):
         self.condition = None
         self.then = None
-        self.folded = False
 
-    def toggle_fold(self):
-        self.folded = not self.folded
     def header(self):
-        if self.folded:
-            return "else if statement: ..."
         return "else if statement:"
     def child_nodes(self) -> None | list:
-        if self.folded:
-            return None
         return [self.condition, self.then]
 
     def string(self, indent = 0):
@@ -429,17 +350,10 @@ class WhileLoop:
         self.condition = None
         self.body = None
         self.is_do = False
-        self.folded = False
 
-    def toggle_fold(self):
-        self.folded = not self.folded
     def header(self):
-        if self.folded:
-            return f"{'do' if self.is_do else ''} while statement: ..."
-        return "while statement:"
+        return f"{'do' if self.is_do else ''} while statement:"
     def child_nodes(self) -> None | list:
-        if self.folded:
-            return None
         if self.is_do:
             return ["do while", self.condition, self.body]
         return [self.condition, self.body]
@@ -457,17 +371,10 @@ class ForLoop:
         self.condition = None
         self.update = None
         self.body = None
-        self.folded = False
 
-    def toggle_fold(self):
-        self.folded = not self.folded
     def header(self):
-        if self.folded:
-            return "for loop: ..."
         return "for loop:"
     def child_nodes(self) -> None | list:
-        if self.folded:
-            return None
         return [self.init, self.condition, self.update, self.body]
 
     def string(self, indent = 0):
@@ -485,17 +392,10 @@ class Function:
         self.rtype = None
         self.params: list[Parameter] = []
         self.body = None
-        self.folded = False
 
-    def toggle_fold(self):
-        self.folded = not self.folded
     def header(self):
-        if self.folded:
-            return f"function: {self.id.string()} ..."
         return f"function: {self.id.string()}"
     def child_nodes(self) -> None | list:
-        if self.folded:
-            return None
         return [self.rtype, self.params, self.body]
 
     def string(self, indent = 0):
@@ -518,17 +418,10 @@ class Class:
         self.body: list = []
         self.properties: list = []
         self.methods: list = []
-        self.folded = False
 
-    def toggle_fold(self):
-        self.folded = not self.folded
     def header(self):
-        if self.folded:
-            return f"class: {self.id.string()} ..."
         return f"class: {self.id.string()}"
     def child_nodes(self) -> None | list:
-        if self.folded:
-            return None
         return [self.params, self.body, self.properties, self.methods]
 
     def string(self, indent = 0):
@@ -553,17 +446,10 @@ class Class:
 class BlockStatement:
     def __init__(self):
         self.statements = []
-        self.folded = False
 
-    def toggle_fold(self):
-        self.folded = not self.folded
     def header(self):
-        if self.folded:
-            return "block: ..."
         return "block"
     def child_nodes(self) -> None | list:
-        if self.folded:
-            return None
         return self.statements
 
     def string(self, indent = 0):

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -1,4 +1,9 @@
 from src.lexer import Token
+
+### BASE CLASS
+# for type checking
+class Production:
+    pass
 '''
 All productions must have these methods:
 1. string(self, indent = 0)
@@ -23,7 +28,7 @@ def sprintln(*val, indent = 0):
     return sprint(*val, indent=indent) + "\n"
 
 ### EXPRESSION PRODUCTIONS
-class PrefixExpression:
+class PrefixExpression(Production):
     def __init__(self):
         self.op = None
         self.right = None
@@ -38,7 +43,7 @@ class PrefixExpression:
     def __len__(self):
         return 1
 
-class InfixExpression:
+class InfixExpression(Production):
     def __init__(self):
         self.left = None
         self.op = None
@@ -53,7 +58,7 @@ class InfixExpression:
     def __len__(self):
         return 1
 
-class PostfixExpression:
+class PostfixExpression(Production):
     def __init__(self):
         self.left = None
         self.op = None
@@ -68,7 +73,7 @@ class PostfixExpression:
         return 1
 
 ### LITERAL PRODUCTIONS
-class StringFmt:
+class StringFmt(Production):
     def __init__(self):
         self.start = None
         self.mid = []
@@ -105,7 +110,7 @@ class StringFmt:
     def __len__(self):
         return 1
 
-class ArrayLiteral:
+class ArrayLiteral(Production):
     def __init__(self):
         self.elements = []
 
@@ -124,7 +129,7 @@ class ArrayLiteral:
     def __iter__(self):
         return iter(self.elements)
 
-class FnCall:
+class FnCall(Production):
     def __init__(self):
         self.id = None
         self.args = []
@@ -155,7 +160,7 @@ class FnCall:
         return 1
 
 ### GENERAL STATEMENT PRODUCTIONS ###
-class ReturnStatement:
+class ReturnStatement(Production):
     def __init__(self):
         self.expr = None
 
@@ -169,7 +174,7 @@ class ReturnStatement:
     def __len__(self):
         return 1
 
-class ArrayDeclaration:
+class ArrayDeclaration(Production):
     def __init__(self):
         self.id: Token = None
         self.dtype = None
@@ -208,7 +213,7 @@ class ArrayDeclaration:
 
         compute_lengths(self.value, 0)
 
-class UselessIdStatement:
+class UselessIdStatement(Production):
     def __init__(self):
         self.id: Token = None
 
@@ -220,7 +225,7 @@ class UselessIdStatement:
     def string(self, indent = 0):
         return sprintln("id:", self.id.string(), indent=indent)
 
-class Assignment:
+class Assignment(Production):
     def __init__(self):
         self.id: Token = None
         self.value = None
@@ -237,7 +242,7 @@ class Assignment:
     def __len__(self):
         return 1
 
-class Declaration:
+class Declaration(Production):
     def __init__(self):
         self.id = None
         self.dtype = None
@@ -258,7 +263,7 @@ class Declaration:
             res += sprintln("value:", self.value.string(indent+1), indent=indent+1)
         return res
 
-class Print:
+class Print(Production):
     def __init__(self):
         self.values = []
 
@@ -273,7 +278,7 @@ class Print:
             res += sprintln(v.string(), indent=indent+1)
         return res
 
-class Input:
+class Input(Production):
     def __init__(self):
         self.value = None
 
@@ -288,7 +293,7 @@ class Input:
         print(f"{INDENT(indent)} input: ", end='')
         self.value.print(indent)
 
-class Parameter:
+class Parameter(Production):
     def __init__(self):
         self.id = None
         self.dtype = None
@@ -304,7 +309,7 @@ class Parameter:
         return res
 
 ### BLOCK STATEMENT PRODUCTIONS
-class IfStatement:
+class IfStatement(Production):
     def __init__(self):
         self.condition = None
         self.then = None
@@ -328,7 +333,7 @@ class IfStatement:
             res += self.else_block.string(indent+2)
         return res
 
-class ElseIfStatement:
+class ElseIfStatement(Production):
     def __init__(self):
         self.condition = None
         self.then = None
@@ -345,7 +350,7 @@ class ElseIfStatement:
         res += self.then.string(indent+2)
         return res
 
-class WhileLoop:
+class WhileLoop(Production):
     def __init__(self):
         self.condition = None
         self.body = None
@@ -365,7 +370,7 @@ class WhileLoop:
         res += self.body.string(indent+2)
         return res
 
-class ForLoop:
+class ForLoop(Production):
     def __init__(self):
         self.init = None # can be declaration or just an ident
         self.condition = None
@@ -386,7 +391,7 @@ class ForLoop:
         res += self.body.string(indent+2)
         return res
 
-class Function:
+class Function(Production):
     def __init__(self):
         self.id = None
         self.rtype = None
@@ -411,7 +416,7 @@ class Function:
         res += self.body.string(indent+2)
         return res
 
-class Class:
+class Class(Production):
     def __init__(self):
         self.id = None
         self.params: list = []
@@ -443,7 +448,7 @@ class Class:
             res += self.body.string(indent+2)
         return res
 
-class BlockStatement:
+class BlockStatement(Production):
     def __init__(self):
         self.statements = []
 
@@ -458,7 +463,7 @@ class BlockStatement:
             res += s.string(indent+1)
         return res
 
-class Program:
+class Program(Production):
     'the root node of the syntax tree'
     def __init__(self):
         self.mainuwu = None

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -322,29 +322,25 @@ class Program:
         self.functions: list = []
         self.classes: list = []
 
-    # TODO: change property names later (add underscores in __init__())
-    #   not changing them now to avoid conflicts
-    #   in another branch
-
-    def main(self, indent = 0):
+    def mainuwu_string(self, indent = 0):
         if not self.mainuwu:
             return ''
         res = self.mainuwu.string(indent)
         return res + "\n"
 
-    def globs(self, indent = 0):
+    def globals_string(self, indent = 0):
         res = ''
         for g in self.globals:
             res += g.string(indent)
         return res + "\n"
 
-    def funcs(self, indent = 0):
+    def functions_string(self, indent = 0):
         res = ''
         for fn in self.functions:
             res += fn.string(indent)
         return res + "\n"
 
-    def _classes(self, indent = 0):
+    def classes_string(self, indent = 0):
         res = ''
         for c in self.classes:
             res += c.string(indent)
@@ -352,11 +348,11 @@ class Program:
 
     def __str__(self):
         res = "MAINUWU:\n"
-        res += self.main(1)
+        res += self.mainuwu_string(1)
         res += "GLOBALS:\n"
-        res += self.globs(1)
+        res += self.globals_string(1)
         res += "FUNCTIONS:\n"
-        res += self.funcs(1)
+        res += self.functions_string(1)
         res += "CLASSES:\n"
-        res += self._classes(1)
+        res += self.classes_string(1)
         return res


### PR DESCRIPTION
### New
1. `header()` method return the representation of the production
   - this representation can either be a title (for prods containing other prods) or the value itself (for atomic prods like infix expression, return statement, etc)
   - always returns a string
2. `child_nodes()` to get the child nodes if any
   - can return a list of production classes if any
   - if no child nodes (aka an atomic prod), returns `None`

### Changes
- renamed `Program` methods that return string representations of its properties appropriately

### etc
- fixed bug where if there's no `mainuwu` function, the entire `Program` class is `None`