### PR TITLE
`child_nodes()` returns a dict instead of list for additional context for GUI

### DIFF
--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -14,10 +14,10 @@ All productions must have these methods:
     - titles are for class productions
     - values are for atomic productions
 
-3. child_nodes(self) -> None | list[production classes]
+3. child_nodes(self) -> None | dict[Production, str]
     - returns None if atomic (aka leaf)
         - the value of the atomic production is in the header() method
-    - returns a list of other production classes if not
+    - returns a dict of key:val where key is the title of the child and val is the production
 '''
 
 def sprint(*val, indent = 0):
@@ -35,7 +35,7 @@ class PrefixExpression(Production):
 
     def header(self):
         return self.string()
-    def child_nodes(self) -> None | list:
+    def child_nodes(self) -> None | dict[Production, str]:
         return None
 
     def string(self, _ = 1):
@@ -50,7 +50,7 @@ class InfixExpression(Production):
         self.right = None
     def header(self):
         return self.string()
-    def child_nodes(self) -> None | list:
+    def child_nodes(self) -> None | dict[Production, str]:
         return None
 
     def string(self, _ = 1):
@@ -64,7 +64,7 @@ class PostfixExpression(Production):
         self.op = None
     def header(self):
         return self.string()
-    def child_nodes(self) -> None | list:
+    def child_nodes(self) -> None | dict[Production, str]:
         return None
 
     def string(self, _ = 1):
@@ -82,8 +82,8 @@ class StringFmt(Production):
 
     def header(self):
         return "string fmt:"
-    def child_nodes(self) -> None | list:
-        return [self.start, self.mid_expr(), self.end]
+    def child_nodes(self) -> None | dict[Production, str]:
+        return {"start:":self.start, **{f"mid_{i+1}":m for i,m in enumerate(self.mid_expr_iter())}, "end":self.end}
 
     def string(self, indent = 0):
         res = sprintln("string fmt:", indent=0)
@@ -116,8 +116,8 @@ class ArrayLiteral(Production):
 
     def header(self):
         return "array literal:"
-    def child_nodes(self) -> None | list:
-        return self.elements
+    def child_nodes(self) -> None | dict[Production, str]:
+        return {f"item_{i+1}":e for i,e in enumerate(self.elements)}
 
     def string(self, indent = 0):
         res = sprintln("array literal:", indent=0)
@@ -144,7 +144,7 @@ class FnCall(Production):
                         f'({", ".join([a.string() for a in self.args])})',
                         indent=0)
 
-    def child_nodes(self) -> None | list:
+    def child_nodes(self) -> None | dict[Production, str]:
         return None
 
     def string(self, indent = 1):
@@ -166,7 +166,7 @@ class ReturnStatement(Production):
 
     def header(self):
         return self.string()
-    def child_nodes(self) -> None | list:
+    def child_nodes(self) -> None | dict[Production, str]:
         return None
 
     def string(self, indent = 0):
@@ -182,9 +182,9 @@ class ArrayDeclaration(Production):
         self.is_const: bool = False
 
     def header(self):
-        return f"declare array: {self.id.string()}"
-    def child_nodes(self) -> None | list:
-        return [self.dtype, self.value, self.is_const]
+        return f"declare{' constant' if self.is_const else ''} array: {self.id.string()}"
+    def child_nodes(self) -> None | dict[Production, str]:
+        return {"dtype:":self.dtype, "value:":self.value}
 
     def string(self, indent = 0):
         res = sprintln("declare array:", self.id.string(), indent=indent)
@@ -219,7 +219,7 @@ class UselessIdStatement(Production):
 
     def header(self):
         return self.string()
-    def child_nodes(self) -> None | list:
+    def child_nodes(self) -> None | dict[Production, str]:
         return None
 
     def string(self, indent = 0):
@@ -232,8 +232,8 @@ class Assignment(Production):
 
     def header(self):
         return f"assign: {self.id.string()}"
-    def child_nodes(self) -> None | list:
-        return [self.value]
+    def child_nodes(self) -> None | dict[Production, str]:
+        return {"value:": self.value}
 
     def string(self, indent = 0):
         res = sprintln("assign:", self.id.string(), indent=indent)
@@ -250,9 +250,9 @@ class Declaration(Production):
         self.is_const: bool = False
 
     def header(self):
-        return f"declare: {self.id.string()}"
-    def child_nodes(self) -> None | list:
-        return [self.dtype, self.value, self.is_const]
+        return f"declare {'constant' if self.is_const else 'variable'}: {self.id.string()}"
+    def child_nodes(self) -> None | dict[Production, str]:
+        return {"dtype:":self.dtype, "value:":self.value}
 
     def string(self, indent = 0):
         res = sprintln("declare:", self.id.string(), indent=indent)
@@ -268,9 +268,9 @@ class Print(Production):
         self.values = []
 
     def header(self):
-        return "print"
-    def child_nodes(self) -> None | list:
-        return self.values
+        return "print:"
+    def child_nodes(self) -> None | dict[Production, str]:
+        return {**{f"val_{i+1}":v for i,v in enumerate(self.values)}}
 
     def string(self, indent = 0):
         res = sprintln("print:", indent=indent)
@@ -284,8 +284,8 @@ class Input(Production):
 
     def header(self):
         return "input"
-    def child_nodes(self) -> None | list:
-        return [self.value]
+    def child_nodes(self) -> None | dict[Production, str]:
+        return {"value:":self.value}
 
     def string(self, indent = 0):
         return sprintln("input:", self.value.string(), indent=indent)
@@ -299,8 +299,8 @@ class Parameter(Production):
         self.dtype = None
 
     def header(self):
-        return f"param: id: {self.id.string()} dtype: {self.dtype.string()}"
-    def child_nodes(self) -> None | list:
+        return f"id: {self.id.string()}, dtype: {self.dtype.string()}"
+    def child_nodes(self) -> None | dict[Production, str]:
         return None
 
     def string(self, indent = 0):
@@ -318,8 +318,8 @@ class IfStatement(Production):
 
     def header(self):
         return "if statement:"
-    def child_nodes(self) -> None | list:
-        return [self.condition, self.then, self.else_if, self.else_block]
+    def child_nodes(self) -> None | dict[Production, str]:
+        return {"condition:":self.condition, "then:":self.then, **{"":e for e in self.else_if}, "else:":self.else_block}
 
     def string(self, indent = 0):
         res = sprintln("if statement:", indent=indent)
@@ -340,8 +340,8 @@ class ElseIfStatement(Production):
 
     def header(self):
         return "else if statement:"
-    def child_nodes(self) -> None | list:
-        return [self.condition, self.then]
+    def child_nodes(self) -> None | dict[Production, str]:
+        return {"condition:":self.condition, "then:":self.then}
 
     def string(self, indent = 0):
         res = sprintln("else if statement:", indent=indent)
@@ -358,10 +358,8 @@ class WhileLoop(Production):
 
     def header(self):
         return f"{'do' if self.is_do else ''} while statement:"
-    def child_nodes(self) -> None | list:
-        if self.is_do:
-            return ["do while", self.condition, self.body]
-        return [self.condition, self.body]
+    def child_nodes(self) -> None | dict[Production, str]:
+        return {"condition:":self.condition, "body:":self.body}
 
     def string(self, indent = 0):
         res = sprintln(f"{f'do' if self.is_do else ''} while statement:", indent=indent)
@@ -379,8 +377,8 @@ class ForLoop(Production):
 
     def header(self):
         return "for loop:"
-    def child_nodes(self) -> None | list:
-        return [self.init, self.condition, self.update, self.body]
+    def child_nodes(self) -> None | dict[Production, str]:
+        return {"init:":self.init, "condition:":self.condition, "update:":self.update, "body:":self.body}
 
     def string(self, indent = 0):
         res = sprintln("for statement:", indent=indent)
@@ -400,8 +398,8 @@ class Function(Production):
 
     def header(self):
         return f"function: {self.id.string()}"
-    def child_nodes(self) -> None | list:
-        return [self.rtype, self.params, self.body]
+    def child_nodes(self) -> None | dict[Production, str]:
+        return {"rtype:":self.rtype, **{f"param_{i+1}":p for i,p in enumerate(self.params)}, "body:":self.body}
 
     def string(self, indent = 0):
         res = sprintln("function:", self.id.string(), indent=indent)
@@ -420,14 +418,17 @@ class Class(Production):
     def __init__(self):
         self.id = None
         self.params: list = []
-        self.body: list = []
+        self.body: BlockStatement = None
         self.properties: list = []
         self.methods: list = []
 
     def header(self):
         return f"class: {self.id.string()}"
-    def child_nodes(self) -> None | list:
-        return [self.params, self.body, self.properties, self.methods]
+    def child_nodes(self) -> None | dict[Production, str]:
+        return {**{f"param_{i+1}":p for i,p in enumerate(self.params)},
+                "body:":self.body,
+                **{f"property_{i+1}":p for i,p in enumerate(self.properties)},
+                **{f"method_{i+1}":m for i,m in enumerate(self.methods)}}
 
     def string(self, indent = 0):
         res = sprintln("class:", self.id.string(), indent=indent)
@@ -454,8 +455,8 @@ class BlockStatement(Production):
 
     def header(self):
         return "block"
-    def child_nodes(self) -> None | list:
-        return self.statements
+    def child_nodes(self) -> None | dict[Production, str]:
+        return {**{"":s for s in self.statements}}
 
     def string(self, indent = 0):
         res = sprintln("block:", indent=indent)

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -83,7 +83,7 @@ class StringFmt(Production):
     def header(self):
         return "string fmt:"
     def child_nodes(self) -> None | dict[Production, str]:
-        return {"start:":self.start, **{f"mid_{i+1}":m for i,m in enumerate(self.mid_expr_iter())}, "end":self.end}
+        return {"start:":self.start, **{f"mid_{i+1}:":m for i,m in enumerate(self.mid_expr_iter())}, "end:":self.end}
 
     def string(self, indent = 0):
         res = sprintln("string fmt:", indent=0)
@@ -117,7 +117,7 @@ class ArrayLiteral(Production):
     def header(self):
         return "array literal:"
     def child_nodes(self) -> None | dict[Production, str]:
-        return {f"item_{i+1}":e for i,e in enumerate(self.elements)}
+        return {f"item_{i+1}:":e for i,e in enumerate(self.elements)}
 
     def string(self, indent = 0):
         res = sprintln("array literal:", indent=0)
@@ -270,7 +270,7 @@ class Print(Production):
     def header(self):
         return "print:"
     def child_nodes(self) -> None | dict[Production, str]:
-        return {**{f"val_{i+1}":v for i,v in enumerate(self.values)}}
+        return {**{f"val_{i+1}:":v for i,v in enumerate(self.values)}}
 
     def string(self, indent = 0):
         res = sprintln("print:", indent=indent)
@@ -399,7 +399,7 @@ class Function(Production):
     def header(self):
         return f"function: {self.id.string()}"
     def child_nodes(self) -> None | dict[Production, str]:
-        return {"rtype:":self.rtype, **{f"param_{i+1}":p for i,p in enumerate(self.params)}, "body:":self.body}
+        return {"rtype:":self.rtype, **{f"param_{i+1}:":p for i,p in enumerate(self.params)}, "body:":self.body}
 
     def string(self, indent = 0):
         res = sprintln("function:", self.id.string(), indent=indent)
@@ -425,10 +425,10 @@ class Class(Production):
     def header(self):
         return f"class: {self.id.string()}"
     def child_nodes(self) -> None | dict[Production, str]:
-        return {**{f"param_{i+1}":p for i,p in enumerate(self.params)},
+        return {**{f"param_{i+1}:":p for i,p in enumerate(self.params)},
                 "body:":self.body,
-                **{f"property_{i+1}":p for i,p in enumerate(self.properties)},
-                **{f"method_{i+1}":m for i,m in enumerate(self.methods)}}
+                **{f"property_{i+1}:":p for i,p in enumerate(self.properties)},
+                **{f"method_{i+1}:":m for i,m in enumerate(self.methods)}}
 
     def string(self, indent = 0):
         res = sprintln("class:", self.id.string(), indent=indent)

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -14,7 +14,7 @@ All productions must have these methods:
     - titles are for class productions
     - values are for atomic productions
 
-3. child_nodes(self) -> None | dict[Production, str]
+3. child_nodes(self) -> None | dict[str, Production]
     - returns None if atomic (aka leaf)
         - the value of the atomic production is in the header() method
     - returns a dict of key:val where key is the title of the child and val is the production
@@ -35,7 +35,7 @@ class PrefixExpression(Production):
 
     def header(self):
         return self.string()
-    def child_nodes(self) -> None | dict[Production, str]:
+    def child_nodes(self) -> None | dict[str, Production]:
         return None
 
     def string(self, _ = 1):
@@ -50,7 +50,7 @@ class InfixExpression(Production):
         self.right = None
     def header(self):
         return self.string()
-    def child_nodes(self) -> None | dict[Production, str]:
+    def child_nodes(self) -> None | dict[str, Production]:
         return None
 
     def string(self, _ = 1):
@@ -64,7 +64,7 @@ class PostfixExpression(Production):
         self.op = None
     def header(self):
         return self.string()
-    def child_nodes(self) -> None | dict[Production, str]:
+    def child_nodes(self) -> None | dict[str, Production]:
         return None
 
     def string(self, _ = 1):
@@ -82,7 +82,7 @@ class StringFmt(Production):
 
     def header(self):
         return "string fmt:"
-    def child_nodes(self) -> None | dict[Production, str]:
+    def child_nodes(self) -> None | dict[str, Production]:
         return {"start:":self.start, **{f"mid_{i+1}:":m for i,m in enumerate(self.mid_expr_iter())}, "end:":self.end}
 
     def string(self, indent = 0):
@@ -116,7 +116,7 @@ class ArrayLiteral(Production):
 
     def header(self):
         return "array literal:"
-    def child_nodes(self) -> None | dict[Production, str]:
+    def child_nodes(self) -> None | dict[str, Production]:
         return {f"item_{i+1}:":e for i,e in enumerate(self.elements)}
 
     def string(self, indent = 0):
@@ -144,7 +144,7 @@ class FnCall(Production):
                         f'({", ".join([a.string() for a in self.args])})',
                         indent=0)
 
-    def child_nodes(self) -> None | dict[Production, str]:
+    def child_nodes(self) -> None | dict[str, Production]:
         return None
 
     def string(self, indent = 1):
@@ -166,7 +166,7 @@ class ReturnStatement(Production):
 
     def header(self):
         return self.string()
-    def child_nodes(self) -> None | dict[Production, str]:
+    def child_nodes(self) -> None | dict[str, Production]:
         return None
 
     def string(self, indent = 0):
@@ -183,7 +183,7 @@ class ArrayDeclaration(Production):
 
     def header(self):
         return f"declare{' constant' if self.is_const else ''} array: {self.id.string()}"
-    def child_nodes(self) -> None | dict[Production, str]:
+    def child_nodes(self) -> None | dict[str, Production]:
         return {"dtype:":self.dtype, "value:":self.value}
 
     def string(self, indent = 0):
@@ -219,7 +219,7 @@ class UselessIdStatement(Production):
 
     def header(self):
         return self.string()
-    def child_nodes(self) -> None | dict[Production, str]:
+    def child_nodes(self) -> None | dict[str, Production]:
         return None
 
     def string(self, indent = 0):
@@ -232,7 +232,7 @@ class Assignment(Production):
 
     def header(self):
         return f"assign: {self.id.string()}"
-    def child_nodes(self) -> None | dict[Production, str]:
+    def child_nodes(self) -> None | dict[str, Production]:
         return {"value:": self.value}
 
     def string(self, indent = 0):
@@ -251,7 +251,7 @@ class Declaration(Production):
 
     def header(self):
         return f"declare {'constant' if self.is_const else 'variable'}: {self.id.string()}"
-    def child_nodes(self) -> None | dict[Production, str]:
+    def child_nodes(self) -> None | dict[str, Production]:
         return {"dtype:":self.dtype, "value:":self.value}
 
     def string(self, indent = 0):
@@ -269,7 +269,7 @@ class Print(Production):
 
     def header(self):
         return "print:"
-    def child_nodes(self) -> None | dict[Production, str]:
+    def child_nodes(self) -> None | dict[str, Production]:
         return {**{f"val_{i+1}:":v for i,v in enumerate(self.values)}}
 
     def string(self, indent = 0):
@@ -284,7 +284,7 @@ class Input(Production):
 
     def header(self):
         return "input"
-    def child_nodes(self) -> None | dict[Production, str]:
+    def child_nodes(self) -> None | dict[str, Production]:
         return {"value:":self.value}
 
     def string(self, indent = 0):
@@ -300,7 +300,7 @@ class Parameter(Production):
 
     def header(self):
         return f"id: {self.id.string()}, dtype: {self.dtype.string()}"
-    def child_nodes(self) -> None | dict[Production, str]:
+    def child_nodes(self) -> None | dict[str, Production]:
         return None
 
     def string(self, indent = 0):
@@ -318,7 +318,7 @@ class IfStatement(Production):
 
     def header(self):
         return "if statement:"
-    def child_nodes(self) -> None | dict[Production, str]:
+    def child_nodes(self) -> None | dict[str, Production]:
         return {"condition:":self.condition, "then:":self.then, **{"":e for e in self.else_if}, "else:":self.else_block}
 
     def string(self, indent = 0):
@@ -340,7 +340,7 @@ class ElseIfStatement(Production):
 
     def header(self):
         return "else if statement:"
-    def child_nodes(self) -> None | dict[Production, str]:
+    def child_nodes(self) -> None | dict[str, Production]:
         return {"condition:":self.condition, "then:":self.then}
 
     def string(self, indent = 0):
@@ -358,7 +358,7 @@ class WhileLoop(Production):
 
     def header(self):
         return f"{'do' if self.is_do else ''} while statement:"
-    def child_nodes(self) -> None | dict[Production, str]:
+    def child_nodes(self) -> None | dict[str, Production]:
         return {"condition:":self.condition, "body:":self.body}
 
     def string(self, indent = 0):
@@ -377,7 +377,7 @@ class ForLoop(Production):
 
     def header(self):
         return "for loop:"
-    def child_nodes(self) -> None | dict[Production, str]:
+    def child_nodes(self) -> None | dict[str, Production]:
         return {"init:":self.init, "condition:":self.condition, "update:":self.update, "body:":self.body}
 
     def string(self, indent = 0):
@@ -398,7 +398,7 @@ class Function(Production):
 
     def header(self):
         return f"function: {self.id.string()}"
-    def child_nodes(self) -> None | dict[Production, str]:
+    def child_nodes(self) -> None | dict[str, Production]:
         return {"rtype:":self.rtype, **{f"param_{i+1}:":p for i,p in enumerate(self.params)}, "body:":self.body}
 
     def string(self, indent = 0):
@@ -424,7 +424,7 @@ class Class(Production):
 
     def header(self):
         return f"class: {self.id.string()}"
-    def child_nodes(self) -> None | dict[Production, str]:
+    def child_nodes(self) -> None | dict[str, Production]:
         return {**{f"param_{i+1}:":p for i,p in enumerate(self.params)},
                 "body:":self.body,
                 **{f"property_{i+1}:":p for i,p in enumerate(self.properties)},
@@ -455,7 +455,7 @@ class BlockStatement(Production):
 
     def header(self):
         return "block"
-    def child_nodes(self) -> None | dict[Production, str]:
+    def child_nodes(self) -> None | dict[str, Production]:
         return {**{"":s for s in self.statements}}
 
     def string(self, indent = 0):


### PR DESCRIPTION
`key:val` where `key` is the title of the Production and `val` is the Production itself. The value of the production is still the `header()` so no changes there.

### Notes:
- some productions don't have titles; key is `""`
- reworked `child_nodes()` so if `child_nodes()` exist, all values can only be `Production`
  - no list or dict as items, those are unpacked
  - example:
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/b2a4a06a-1766-461f-81e5-cd559448304c)
