### PR TITLE
Feat/array return types

### DIFF
--- a/constants/constants.py
+++ b/constants/constants.py
@@ -40,7 +40,7 @@ DELIMS = {
     'close_parenthesis': {' ', *ATOMS['general_operator'], '!', '&', '|', '\n', '~', '>', '.', ',', ')', '(', '[', ']', '}'},
     'open_bracket': {']', *ATOMS['number'], '-', *ATOMS['alpha'], '(', ' '},
     'double_open_bracket': {' ', '\n', *ATOMS['alpha'], '>'},
-    'close_bracket': {'[', ' ', '~', ',', ')', '[', ']', '}', *ATOMS['general_operator'], '!', r'&', '|', '.',},
+    'close_bracket': {'(', ' ', '~', ',', ')', '[', ']', '}', *ATOMS['general_operator'], '!', r'&', '|', '.',},
     'double_close_bracket': {' ', '\n', *ATOMS['alpha'], '>'},
     'unary': {'|', '~', ')', *ATOMS['general_operator'], '!', ' '},
     'concat': {' ', '"', *ATOMS['alpha']},

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -341,7 +341,16 @@ class Parser:
                     self.no_data_type_error(self.peek_tok)
                     self.advance(2)
                     return func
+
         func.rtype = self.curr_tok
+
+        # is array return type
+        if self.expect_peek(TokenType.OPEN_BRACKET):
+            if not self.expect_peek(TokenType.CLOSE_BRACKET):
+                self.unclosed_bracket_error(self.peek_tok)
+                self.advance(2)
+            func.rtype.lexeme += "[]"
+
         func.params = self.parse_params(main=main)
         if not self.expect_peek(TokenType.DOUBLE_OPEN_BRACKET):
             self.peek_error(TokenType.DOUBLE_OPEN_BRACKET)

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -349,6 +349,7 @@ class Parser:
             if not self.expect_peek(TokenType.CLOSE_BRACKET):
                 self.unclosed_bracket_error(self.peek_tok)
                 self.advance(2)
+                return func
             func.rtype.lexeme += "[]"
 
         func.params = self.parse_params(main=main)

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -1175,14 +1175,14 @@ class Parser:
     def multiple_mainuwu_error(self, token: Token):
         self.errors.append(Error(
             "MULTIPLE MAINUWU FUNCTION",
-            f"The program must only have one mainuwu function.",
+            f"The program must only have one mainuwu function. Got 'mainuwu'",
             token.position,
             token.end_position
         ))
     def missing_mainuwu_error(self, token: Token):
         self.errors.append(Error(
             "MISSING MAINUWU FUNCTION",
-            f"The program must have at least one mainuwu function.",
+            f"The program must have at least one mainuwu function. Got 'EOF'",
             token.position,
             token.end_position
         ))


### PR DESCRIPTION
closes #110 

### changes
- allow `]` to be delimited by `(`
- array rtypes are read and parsed properly

### etc
- mainuwu errors missing the "got" context in error message. added it

#### tokenized
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/7a704183-2e91-4238-bb38-dcd49a4bd007)

#### parsed
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/5647e48b-df3c-4cd3-a4c7-068acf244bbb)
