### PR TITLE
Feat/parse logical operators

### DIFF
--- a/src/lexer/lexer.py
+++ b/src/lexer/lexer.py
@@ -208,6 +208,9 @@ class Lexer():
             
             # string literals
             if self._current_char in ['|', '"']:
+                cursor_advanced = self.peek_reserved('||', TokenType.OR_OPERATOR)
+                if cursor_advanced:
+                    continue
                 self.peek_string()
                 if self._at_EOF:
                     break

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -6,9 +6,9 @@ from .error_handler import ErrorSrc
 if __name__ == "__main__":
     sc = """
     fwunc mainuwu-san() [[
-        iwf (fax) [[
+        iwf (fax || cap && 1+1) [[
             a-san[] = 20~
-        ]] ewse iwf (4 == 5) [[
+        ]] ewse iwf (4 != 5 || 6 == 7) [[
             aqua-sama = 6~
             shion-sama = 6~
             ojou-sama = 6~

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -33,23 +33,28 @@ from src.parser.productions import *
 To keep track of the precedence of each token.
 
 idents:                 LOWEST
-==, !=, <, >, <=, >=:   EQUALS
+&&, ||                  LOGICAL
+==, !=                  EQUALITY
+<, >, <=, >=:           LESS_GREATER
 +, -:                   SUM
 *, /, %:                PRODUCT
 - (as in negative):     PREFIX
 ident():                FN_CALL
 '''
 LOWEST = 0
-EQUALS = 1
-LESS_GREATER = 2
-SUM = 3
-PRODUCT = 4
-PREFIX = 5
-FN_CALL = 6
+LOGICAL = 1
+EQUALITY = 2
+LESS_GREATER = 3
+SUM = 4
+PRODUCT = 5
+PREFIX = 6
+FN_CALL = 7
 
 precedence_map = {
-    TokenType.EQUALITY_OPERATOR: EQUALS,
-    TokenType.INEQUALITY_OPERATOR: EQUALS,
+    TokenType.AND_OPERATOR: LOGICAL,
+    TokenType.OR_OPERATOR: LOGICAL,
+    TokenType.EQUALITY_OPERATOR: EQUALITY,
+    TokenType.INEQUALITY_OPERATOR: EQUALITY,
     TokenType.LESS_THAN_SIGN: LESS_GREATER,
     TokenType.LESS_THAN_OR_EQUAL_SIGN: LESS_GREATER,
     TokenType.GREATER_THAN_SIGN: LESS_GREATER,
@@ -143,6 +148,8 @@ class Parser:
         # infixes
         self.register_infix(TokenType.EQUALITY_OPERATOR, self.parse_infix_expression)
         self.register_infix(TokenType.INEQUALITY_OPERATOR, self.parse_infix_expression)
+        self.register_infix(TokenType.AND_OPERATOR, self.parse_infix_expression)
+        self.register_infix(TokenType.OR_OPERATOR, self.parse_infix_expression)
         self.register_infix(TokenType.LESS_THAN_SIGN, self.parse_infix_expression)
         self.register_infix(TokenType.LESS_THAN_OR_EQUAL_SIGN, self.parse_infix_expression)
         self.register_infix(TokenType.GREATER_THAN_SIGN, self.parse_infix_expression)


### PR DESCRIPTION
### new
- parse logical operators

### changes
- separate precedence of equality operators and comparison operators to align with the paper

### etc
- lexer: when encountering `|` check if logical operator first before treating as string part mid
