### PR TITLE
Feat/parse error returns none

### DIFF
--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -5,17 +5,34 @@ from .error_handler import ErrorSrc
 if __name__ == "__main__":
     sc = """
     cwass Ojou()[[
+        aqua-chan = 1~
         Ojou.ojou = Shion.shion[1][2]
             .aqua("hello")[3]
             .shion
             .aqua(arg1, arg2)[4][5]
             .shion(fax)
             .aqua[6][7][8][9][0]~
+        shion~
 
         aqua-chan = (1+1*ojou(fax || shion != 5)[1]/2)~
+        iwf (fax) [[
+            pwint(fax)~
+            whiwe (1+2 != 3) [[
+                pwint(1+2)~
+            ]]
+        ]] ewse iwf(cap) [[
+            pwint(cap)~
+            do whiwe (fax && cap) [[
+                pwint(fax && cap)~
+            ]]
+        ]] ewse[[
+            pwint()~
+            fow(i~i>10||i<5~i++) [[
+                pwint(test)~
+            ]]
+        ]]
     ]]
     fwunc mainuwu-san() [[
-        a-san[] = 20~
         b()[1].a 
             .aqua("hello")[3]
             .shion
@@ -23,6 +40,7 @@ if __name__ == "__main__":
             .shion(fax)
             .aqua[6][7][8][9][0]-chan-dono = 10~
         c[2][1]~
+        a-san[]~
     ]]
     """
 
@@ -46,8 +64,6 @@ if __name__ == "__main__":
     ErrorSrc.src = source
     p = Parser(l.tokens)
     print()
-    for err in p.errors:
-        print(err)
 
     print("--- Printing Whole Program ---")
     print(p.program)
@@ -61,4 +77,6 @@ if __name__ == "__main__":
     print(p.program.classes_string())
 
     if p.errors:
+        for err in p.errors:
+            print(err)
         exit(1)

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -5,7 +5,7 @@ from .error_handler import ErrorSrc
 if __name__ == "__main__":
     sc = """
     cwass Ojou()[[
-        aqua-chan = 1~
+        aqua-chan = iwf(fax)[[wetuwn(fax)~]] ewse iwf(cap)[[wetuwn(cap)~]] ewse [[ wetuwn(0)~ ]] ~
         Ojou.ojou = Shion.shion[1][2]
             .aqua("hello")[3]
             .shion
@@ -32,6 +32,7 @@ if __name__ == "__main__":
             ]]
         ]]
     ]]
+    gwobaw aqua-chan = {1,2,"hello | -nickname-- | world", 1+1*1, {3.4, 5.6}}~
     fwunc mainuwu-san() [[
         b()[1].a 
             .aqua("hello")[3]

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
             .aqua(arg1, arg2)[4][5]
             .shion(fax)
             .aqua[6][7][8][9][0]~
-        shion~
+        shion()~
 
         aqua-chan = (1+1*ojou(fax || shion != 5)[1]/2)~
         iwf (fax) [[

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -378,7 +378,6 @@ class Parser:
             self.advance(2)
             return None
 
-        print(self.curr_tok, self.peek_tok)
         if (res := self.parse_block_statement()) is None:
             return None
         func.body = res

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -134,7 +134,6 @@ class Parser:
         self.register_prefix(TokenType.OPEN_BRACE, self.parse_array)
         self.register_prefix(TokenType.STRING_PART_START, self.parse_string_parts)
         self.register_prefix(TokenType.OPEN_PAREN, self.parse_grouped_expressions)
-        self.register_prefix(TokenType.IWF, self.parse_if_statement)
 
         # literals (just returns curr_tok)
         self.register_prefix("IDENTIFIER", self.parse_ident)

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -1191,22 +1191,26 @@ class Parser:
         ))
     def no_prefix_parse_fn_error(self, token_type):
         self.errors.append(Error(
-            "MISSING PREFIX PARSING FUNCTION",
-            f"No prefix parsing function found for '{token_type}'",
+            "INVALID EXPRESSION TOKEN",
+            f"'{token_type}' is not a valid starting token for an expression"
+            f"\n\tHint: use identifiers, numbers, strings, booleans, parenthesis enclosed expressions, arrays, or 'nuww'",
             self.curr_tok.position,
             self.curr_tok.end_position
         ))
     def no_in_block_parse_fn_error(self, token_type):
         self.errors.append(Error(
-            "MISSING IN-BLOCK PARSING FUNCTION",
-            f"No in-block parsing function found for {token_type}",
+            "INVALID IN-BLOCK STATEMENT TOKEN",
+            f"'{token_type}' is not a valid starting token for an in-block/body statement."
+            f"\n\tHint: use identifiers, 'inpwt', 'pwint', 'wetuwn', 'iwf', 'whiwe', 'do whiwe', or 'fow'",
             self.curr_tok.position,
             self.curr_tok.end_position
         ))
     def invalid_global_declaration_error(self, token: Token):
         self.errors.append(Error(
             "INVALID GLOBAL DECLARATION",
-            f"Only functions, classes, and global variable declarations are allowed in the global scope.\n\t'{token.lexeme}' is invalid.",
+            f"Only functions, classes, and global variable declarations are allowed in the global scope."
+            f"\n\t'{token.lexeme}' is an invalid starting token for global declarations."
+            f"\n\tHint: use 'gwobaw', 'fwunc' or 'cwass'",
             token.position,
             token.end_position
         ))

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -420,7 +420,7 @@ class Parser:
                         if parser is None:
                             self.no_in_block_parse_fn_error(self.curr_tok.token)
                             self.advance()
-                            continue
+                            return None
                         if (statement := parser()) is None:
                             return None
                         c.body.statements.append(statement)
@@ -846,6 +846,7 @@ class Parser:
         prefix = self.get_prefix_parse_fn(self.curr_tok.token)
         if prefix is None:
             self.no_prefix_parse_fn_error(self.curr_tok.token)
+            self.advance()
             return None
 
         left_exp = prefix()


### PR DESCRIPTION
# no functionality changes

---

## properly parse, return `None`
Whenever an error is encountered, instead of returning whatever is parsed so far _(old)_, return `None` _(new)_. This propagates upwards other parsers if nested.

eg. if an error occurred in an if statement that is 5 if statements deep encounters an error:
- 5th will return `None` to 4th
- 4th will return `None` to 3rd
- ...
- the top most if statement will return `None` as well to the Block statement it is in
- the block statement will return `None` to the function it is in (assuming it is in a function)
- the function will return `None` to the class it is in (assuming this function is a method of a class)

This means the entire class is not parsed and whatever is next after that if statement will be treated as a global declaration and parsed as such

---

## Better error messages
- **renamed**: `MISSING PREFIX PARSING FUNCTION` --> `INVALID EXPRESSION TOKEN`
- **renamed**: `MISSING IN-BLOCK PARSING FUNCTION` --> `INVALID IN-BLOCK STATEMENT TOKEN`
- the above 2 errors along with `INVALID GLOBAL DECLARATION` have better error messages with hints on what token to use