### PR TITLE
Add Class Constructor

### DIFF
--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -1007,8 +1007,30 @@ class Parser:
         return ident
 
     def parse_class_ident(self):
+
+        # Class constructor
+        if self.peek_tok_is(TokenType.OPEN_PAREN):
+            cc = ClassConstructor()
+            cc.id = self.curr_tok
+
+            self.advance(2)
+            stop_conditions = [TokenType.CLOSE_PAREN, TokenType.TERMINATOR, TokenType.EOF]
+            while not self.curr_tok_is_in(stop_conditions):
+                if (res := self.parse_expression(LOWEST)) is None:
+                    return None
+                cc.args.append(res)
+                if not self.expect_peek(TokenType.COMMA) and not self.peek_tok_is_in(stop_conditions):
+                    break
+                self.advance()
+            if not self.curr_tok_is(TokenType.CLOSE_PAREN):
+                self.unclosed_paren_error(self.curr_tok)
+                return None
+            return cc
+
+        # Class accessor
         ident = ClassAccessor()
         ident.id = self.curr_tok
+
         if not self.expect_peek(TokenType.DOT_OP):
             self.peek_error(TokenType.DOT_OP)
             self.advance()

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -171,6 +171,28 @@ class IndexedIdentifier(Production):
             ret += f", indices: {', '.join([i.string() for i in self.index])}"
         return ret
 
+
+class ClassConstructor(Production):
+    def __init__(self):
+        self.id = None
+        self.args = []
+
+    def header(self):
+        return sprint("constructor:", self.id.string(),
+                        f'({", ".join([a.string() for a in self.args])})',
+                        indent=0)
+    def child_nodes(self) -> None | dict[str, Production]:
+        return None
+
+    def string(self, _ = 1):
+        return sprint("constructor:", self.id.string(),
+                      f'({", ".join([a.string() for a in self.args])})',
+                      indent=0)
+    def __len__(self):
+        return 1
+
+
+
 class ClassAccessor(Production):
     '''
     id can be:


### PR DESCRIPTION
### Changes:
- new production class and parser method for ClassConstructors
- functions exactly the same as FnCalls, but with class_id as its id
- gets parsed before parsing class accessors

### Sample:
- `ace-Person = Person("Ace")~`