### PR TITLE
Remove cursor advance when checking ident from keyword

### DIFF
--- a/src/lexer/lexer_components/peek.py
+++ b/src/lexer/lexer_components/peek.py
@@ -109,6 +109,8 @@ def reserved(to_check: str, token_type: TokenType,
                 is_end_of_file, current_char = identifier(context, from_keyword=to_check)
                 context = lines, position, current_char, tokens, logs
 
+                return True, is_end_of_file, current_char
+
         is_end_of_file, current_char = advance_cursor(context)
         cursor_advanced = True
 


### PR DESCRIPTION
### Explanation
Currently, kapag nagchecheck tayo ng identifier from a keyword, nagkakaron ng extra advance sa cursor. I think this is because ung `peek.identifier` method ay may cursor advance sa dulo. Eh sa `peek.reserved` method, may cursor advance din sa dulo. So nadodoble.

### What this fixes
Before:
- input: mainuwuchan()
- output tokens: mainuwuchan, )
- issue: hindi naread si (

After:
- input: mainuwuchan()
- output tokens: mainuwuchan, (, )
- issue: oks na