### PR TITLE
Add unary statements

### DIFF
--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -626,6 +626,17 @@ class Parser:
             id_stm.id = ident
             return id_stm
 
+        # is a unary statement
+        if self.expect_peek_in([TokenType.INCREMENT_OPERATOR, TokenType.DECREMENT_OPERATOR]):
+            unary_stm = UnaryStatement()
+            unary_stm.id = ident
+            unary_stm.op = self.curr_tok
+            if not self.expect_peek(TokenType.TERMINATOR):
+                self.advance()
+                self.unterminated_error(self.curr_tok)
+                return None
+            return unary_stm
+
         # is a declaration
         if self.peek_tok_is(TokenType.DASH):
             return self.parse_declaration(ident)

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -287,6 +287,21 @@ class IdStatement(Production):
     def string(self, indent = 0):
         return sprintln(self.id.string(indent), indent=indent)
 
+class UnaryStatement(Production):
+    def __init__(self):
+        self.id: Token = None
+        self.op: Token = None
+
+    def header(self):
+        return self.string()
+
+    def child_nodes(self) -> None | dict[str, Production]:
+        return None
+
+    def string(self, indent = 0):
+        return sprintln("unary:", self.id.string(indent) + self.op.string(), indent=indent)
+
+
 class Assignment(Production):
     def __init__(self):
         self.id: Token = None


### PR DESCRIPTION
### Changes:
- new unary statement production and parser
- located inside `parse_ident_statement`
- sample: `a++~`