### PR TITLE
More Fixes

### DIFF
--- a/constants/constants.py
+++ b/constants/constants.py
@@ -45,7 +45,7 @@ DELIMS = {
     'unary': {'|', '~', ')', *ATOMS['general_operator'], '!', ' '},
     'concat': {' ', '"', *ATOMS['alpha']},
     'line': {'\n', ' ', *ATOMS['alpha'], ']'},
-    'comma': {*ATOMS['alpha'], ' ', *ATOMS['number'], '"', '-', '\n', '>'},
+    'comma': {*ATOMS['alpha'], ' ', *ATOMS['number'], '"', '-', '\n', '>', '{'},
     'dot_op': {*ATOMS['alpha'], '[', '('},
     'start_done': {'\n', ' ', '>'},
     'nuww': {' ', '~', ')', '}', ','},

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -206,8 +206,8 @@ class Parser:
                 case TokenType.GWOBAW:
                     if res := self.parse_declaration():
                         p.globals.append(res)
-                case TokenType.TERMINATOR | TokenType.DOUBLE_CLOSE_BRACKET:
-                    self.advance()
+                # case TokenType.TERMINATOR | TokenType.DOUBLE_CLOSE_BRACKET:
+                #     self.advance()
                 case _:
                     self.invalid_global_declaration_error(self.curr_tok)
                     self.advance()
@@ -390,6 +390,10 @@ class Parser:
             self.advance(2)
             self.unclosed_double_bracket_error(self.curr_tok)
             return None
+
+        # Consume double close bracket
+        self.advance()
+
         return func
 
     def parse_class(self):
@@ -433,6 +437,10 @@ class Parser:
         if not self.curr_tok_is(TokenType.DOUBLE_CLOSE_BRACKET):
             self.unclosed_double_bracket_error(self.curr_tok)
             return None
+
+        # Consume double close bracket
+        self.advance()
+
         return c
 
     def parse_params(self, main=False):

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -970,6 +970,12 @@ class Parser:
                 ident.args.append(res)
                 if not self.expect_peek(TokenType.COMMA) and not self.peek_tok_is_in(stop_conditions):
                     break
+
+                if self.curr_tok_is(TokenType.COMMA) and self.peek_tok_is(TokenType.CLOSE_PAREN):
+                    self.hanging_comma_error(self.peek_tok)
+                    self.advance(2)
+                    return None
+
                 self.advance()
             if not self.curr_tok_is(TokenType.CLOSE_PAREN):
                 self.unclosed_paren_error(self.curr_tok)
@@ -1068,6 +1074,12 @@ class Parser:
             al.elements.append(res)
             if not self.expect_peek(TokenType.COMMA) and not self.peek_tok_is_in(stop_conditions):
                 break
+
+            if self.curr_tok_is(TokenType.COMMA) and self.peek_tok_is(TokenType.CLOSE_BRACE):
+                self.hanging_comma_error(self.peek_tok)
+                self.advance(2)
+                return None
+
             self.advance()
 
         if not self.curr_tok_is(TokenType.CLOSE_BRACE):
@@ -1417,6 +1429,13 @@ class Parser:
         self.errors.append(Error(
             "MISSING MAINUWU FUNCTION",
             f"The program must have at least one mainuwu function. Got 'EOF'",
+            token.position,
+            token.end_position
+        ))
+    def hanging_comma_error(self, token: Token):
+        self.errors.append(Error(
+            "HANGING COMMA",
+            f"Expected a value or expression after the comma, got {token}.",
             token.position,
             token.end_position
         ))


### PR DESCRIPTION
### Fixes
- ignoring of stray double brackets and terminators
- hanging commas being syntatically valid (i.e `{1, 2, }`)
- comma undelimited by `{` (i.e `{1,{2,3}}`)

### Changes
- new error for hanging commas
- hanging comma checks for array literals and function call arguments
- comma delim sit
- removes match case for double bracket and terminator in main program parser
- adds self.advance to function and class parsers