### PR TITLE
Fix/missing prepend

### DIFF
--- a/src/components/analyzer_tabs.py
+++ b/src/components/analyzer_tabs.py
@@ -35,7 +35,7 @@ class UwUParserTab(CTkScrollableFrame):
             
             node_iid = uuid.uuid4()
 
-            self.tree.insert(parent, 'end', iid=node_iid, text=node.header())
+            self.tree.insert(parent, 'end', iid=node_iid, text=f"{key}: {node.header()}" if key else node.header())
 
             for k, v in node.child_nodes().items():
                 if(not isinstance(v, Production)):

--- a/src/components/analyzer_tabs.py
+++ b/src/components/analyzer_tabs.py
@@ -38,13 +38,8 @@ class UwUParserTab(CTkScrollableFrame):
             self.tree.insert(parent, 'end', iid=node_iid, text=f"{key}: {node.header()}" if key else node.header())
 
             for k, v in node.child_nodes().items():
-                if(not isinstance(v, Production)):
-                    if v:
-                        if(not isinstance(v, list)):
-                            self.tree.insert(node_iid, 'end', text=f"{k}: {v}")
-                        else:
-                            for p in v:
-                                loop_tree(node=p, parent=node_iid)
+                if v and not isinstance(v, Production):
+                    self.tree.insert(node_iid, 'end', text=f"{k}: {v}")
                 else:
                     loop_tree(node=v, parent=node_iid, key=k)
 


### PR DESCRIPTION
### changes
- all nodes have prepends now
- removed checking if node is a list since that possibility was removed in #113
> reworked `child_nodes()` so if `child_nodes()` exist, all values can only be `Production`
>    - no list or dict as items, those are unpacked

_correction_: all values can only be either `Production` or `Token`

### examples
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/c84ae349-a4a0-49cb-a96a-7e2999d4ee6a)
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/40ca8e9a-f077-4396-af5a-f04b12622411)