### PR TITLE
Feat/parser err overhaul

### DIFF
--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -5,11 +5,7 @@ from .error_handler import ErrorSrc
 if __name__ == "__main__":
     sc = """
     fwunc mainuwu-san() [[
-        b = {-2}~
-    ]]
-    gwobaw message-senpai = "Hey"~
-    fwunc a-san() [[
-        a++~
+        a = A(a,b,d)~
     ]]
     """
 
@@ -34,8 +30,6 @@ if __name__ == "__main__":
     p = Parser(l.tokens)
     print()
 
-    print("--- Printing Whole Program ---")
-    print(p.program)
     print("\n--- Printing only Main Function ---")
     print(p.program.mainuwu_string())
     print("\n--- Printing only Global Declarations ---")

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -1038,6 +1038,7 @@ class Parser:
                     if ident.args[-1].token.token.startswith('IDENTIFIER') or ident.args[-1].token.token.startswith('CWASS'):
                         added.append(TokenType.DOT_OP)
                 self.expected_error([TokenType.CLOSE_PAREN, *added], curr=True if self.curr_tok_is_in([TokenType.TERMINATOR, TokenType.EOF]) else False)
+                self.advance(2)
                 return None
 
         # array indexing, keep looping until curr tok is not close bracket

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -181,6 +181,7 @@ class Parser:
         self.register_postfix(TokenType.INT_LITERAL, self.parse_postfix_expression)
         self.register_postfix(TokenType.FLOAT_LITERAL, self.parse_postfix_expression)
         self.register_postfix(TokenType.CLOSE_PAREN, self.parse_postfix_expression)
+        self.register_postfix(TokenType.CLOSE_BRACKET, self.parse_postfix_expression)
 
         # in blocks
         self.register_in_block("IDENTIFIER", self.parse_ident_statement)

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -422,7 +422,6 @@ class Parser:
                     if (res := self.parse_function()) is None:
                         return None
                     c.methods.append(res)
-                    self.advance() # consume the double close bracket
                 case _:
                     inner_stop_conditions = stop_conditions + [TokenType.FWUNC]
                     while not self.curr_tok_is_in(inner_stop_conditions):

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -655,14 +655,9 @@ class Parser:
         # is not a declaration or assignment
         expected = [TokenType.DOT_OP, TokenType.TERMINATOR, TokenType.INCREMENT_OPERATOR, TokenType.DECREMENT_OPERATOR,
                     TokenType.DASH, TokenType.ASSIGNMENT_OPERATOR, TokenType.OPEN_BRACKET, TokenType.OPEN_PAREN]
-        if not self.peek_tok_is_in(expected):
+        if self.expect_peek(TokenType.TERMINATOR):
             id_stm = IdStatement()
             id_stm.id = ident
-
-            if not self.expect_peek(TokenType.TERMINATOR):
-                self.expected_error(expected)
-                self.advance(2)
-                return None
             return id_stm
 
         # is a unary statement
@@ -684,7 +679,18 @@ class Parser:
         a = Assignment()
         a.id = ident
         if not self.expect_peek(TokenType.ASSIGNMENT_OPERATOR):
-            self.expected_error([TokenType.DOT_OP, TokenType.TERMINATOR, TokenType.INCREMENT_OPERATOR, TokenType.DECREMENT_OPERATOR, TokenType.DASH, TokenType.ASSIGNMENT_OPERATOR])
+            if isinstance(a.id, IndexedIdentifier):
+                try:
+                    expected.remove(TokenType.OPEN_BRACKET)
+                    expected.remove(TokenType.OPEN_PAREN)
+                except:
+                    pass
+            if isinstance(a.id, FnCall):
+                try:
+                    expected.remove(TokenType.OPEN_PAREN)
+                except:
+                    pass
+            self.expected_error(expected)
             self.advance(2)
             return None
 
@@ -707,17 +713,19 @@ class Parser:
         if (res := self.parse_class_ident()) is None:
             return None
         ident = res
+        if isinstance(ident, ClassConstructor):
+            if not self.expect_peek(TokenType.TERMINATOR):
+                self.peek_error(TokenType.TERMINATOR)
+                self.advance(2)
+                return None
+            return ident
 
         # is not a declaration or assignment
         expected = [TokenType.DOT_OP, TokenType.TERMINATOR, TokenType.INCREMENT_OPERATOR, TokenType.DECREMENT_OPERATOR,
                     TokenType.DASH, TokenType.ASSIGNMENT_OPERATOR, TokenType.OPEN_BRACKET, TokenType.OPEN_PAREN]
-        if not self.peek_tok_is_in(expected):
+        if self.expect_peek(TokenType.TERMINATOR):
             id_stm = IdStatement()
             id_stm.id = ident
-            if not self.expect_peek(TokenType.TERMINATOR):
-                self.expected_error(expected)
-                self.advance(2)
-                return None
             return id_stm
 
         # is a declaration
@@ -728,7 +736,18 @@ class Parser:
         a = Assignment()
         a.id = ident
         if not self.expect_peek(TokenType.ASSIGNMENT_OPERATOR):
-            self.expected_error([TokenType.DOT_OP, TokenType.TERMINATOR, TokenType.INCREMENT_OPERATOR, TokenType.DECREMENT_OPERATOR, TokenType.DASH, TokenType.ASSIGNMENT_OPERATOR])
+            if isinstance(a.id, IndexedIdentifier):
+                try:
+                    expected.remove(TokenType.OPEN_BRACKET)
+                    expected.remove(TokenType.OPEN_PAREN)
+                except:
+                    pass
+            if isinstance(a.id, FnCall):
+                try:
+                    expected.remove(TokenType.OPEN_PAREN)
+                except:
+                    pass
+            self.expected_error(expected)
             self.advance()
             return None
 

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -653,9 +653,16 @@ class Parser:
         ident = res
 
         # is not a declaration or assignment
-        if self.expect_peek(TokenType.TERMINATOR):
+        expected = [TokenType.DOT_OP, TokenType.TERMINATOR, TokenType.INCREMENT_OPERATOR, TokenType.DECREMENT_OPERATOR,
+                    TokenType.DASH, TokenType.ASSIGNMENT_OPERATOR, TokenType.OPEN_BRACKET, TokenType.OPEN_PAREN]
+        if not self.peek_tok_is_in(expected):
             id_stm = IdStatement()
             id_stm.id = ident
+
+            if not self.expect_peek(TokenType.TERMINATOR):
+                self.expected_error(expected)
+                self.advance(2)
+                return None
             return id_stm
 
         # is a unary statement
@@ -702,9 +709,15 @@ class Parser:
         ident = res
 
         # is not a declaration or assignment
-        if self.expect_peek(TokenType.TERMINATOR):
+        expected = [TokenType.DOT_OP, TokenType.TERMINATOR, TokenType.INCREMENT_OPERATOR, TokenType.DECREMENT_OPERATOR,
+                    TokenType.DASH, TokenType.ASSIGNMENT_OPERATOR, TokenType.OPEN_BRACKET, TokenType.OPEN_PAREN]
+        if not self.peek_tok_is_in(expected):
             id_stm = IdStatement()
             id_stm.id = ident
+            if not self.expect_peek(TokenType.TERMINATOR):
+                self.expected_error(expected)
+                self.advance(2)
+                return None
             return id_stm
 
         # is a declaration

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -1,6 +1,5 @@
 '''
 TODOS:
-- add dot ops to expected if last token in expr is identifier/class_id
 - implement value superset and separation of logical and other operators
 '''
 
@@ -338,7 +337,7 @@ class Parser:
 
         if not self.expect_peek(TokenType.CLOSE_PAREN):
             self.expected_error([TokenType.CLOSE_PAREN, *self.error_context(rs.expr)])
-            self.advance()
+            self.advance(2)
             return None
         if not self.expect_peek(TokenType.TERMINATOR):
             self.advance()
@@ -829,7 +828,7 @@ class Parser:
 
         if not self.expect_peek(TokenType.CLOSE_PAREN):
             self.expected_error([TokenType.CLOSE_PAREN, *self.error_context(fl.update)])
-            self.advance()
+            self.advance(2)
             return None
         if not self.expect_peek(TokenType.DOUBLE_OPEN_BRACKET):
             self.peek_error(TokenType.DOUBLE_OPEN_BRACKET)
@@ -1111,11 +1110,11 @@ class Parser:
 
         if not self.expect_peek(TokenType.DOT_OP):
             self.expected_error([TokenType.DOT_OP, TokenType.OPEN_PAREN])
-            self.advance()
+            self.advance(2)
             return None
         if not self.expect_peek_is_identifier():
             self.invalid_dot_op_error(self.peek_tok)
-            self.advance()
+            self.advance(2)
             return None
         if (res := self.parse_ident()) is None:
             return None

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -213,10 +213,8 @@ class Parser:
                     if res := self.parse_declaration():
                         self.advance()
                         p.globals.append(res)
-                # case TokenType.TERMINATOR | TokenType.DOUBLE_CLOSE_BRACKET:
-                #     self.advance()
                 case _:
-                    self.invalid_global_declaration_error(self.curr_tok)
+                    self.expected_error([TokenType.FWUNC, TokenType.CWASS, TokenType.GWOBAW], curr=True)
                     self.advance()
 
         if p.mainuwu is None:

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -79,6 +79,12 @@ class Parser:
         self.infix_parse_fns: dict = {}
         self.postfix_parse_fns: dict = {}
         self.in_block_parse_fns: dict = {}
+        # to keep track of expected tokens
+        self.expected_prefix = []
+        self.expected_infix = []
+        self.expected_postfix = []
+        self.expected_in_block = []
+
         self.register_init()
 
         if not self.tokens:
@@ -139,7 +145,7 @@ class Parser:
 
         # literals (just returns curr_tok)
         self.register_prefix("IDENTIFIER", self.parse_ident)
-        self.register_prefix("CWASS", self.parse_class_ident)
+        self.register_prefix("CWASS_ID", self.parse_class_ident)
         self.register_prefix(TokenType.INT_LITERAL, self.parse_literal)
         self.register_prefix(TokenType.STRING_LITERAL, self.parse_literal)
         self.register_prefix(TokenType.FLOAT_LITERAL, self.parse_literal)
@@ -172,7 +178,7 @@ class Parser:
 
         # in blocks
         self.register_in_block("IDENTIFIER", self.parse_ident_statement)
-        self.register_in_block("CWASS", self.parse_class_ident_statement)
+        self.register_in_block("CWASS_ID", self.parse_class_ident_statement)
         self.register_in_block(TokenType.IWF, self.parse_if_statement)
         self.register_in_block(TokenType.WETUWN, self.parse_return_statement)
         self.register_in_block(TokenType.WHIWE, self.parse_while_statement)
@@ -1246,6 +1252,18 @@ class Parser:
     ### error methods
 
     # general error
+    def expected_error(self, tokens: list[TokenType], curr=False):
+        msg = f"Expected next token to be one of the ff:"
+        for token in tokens[:-1]:
+            msg += f" '{token}',"
+        msg += f" '{tokens[-1]}'"
+        msg += f"\n\tgot '{self.peek_tok if not curr else self.curr_tok}' instead"
+        self.errors.append(Error(
+            "UNEXPECTED TOKEN",
+            msg,
+            self.peek_tok.position if not curr else self.curr_tok.position,
+            self.peek_tok.end_position if not curr else self.curr_tok.end_position
+        ))
     def peek_error(self, token: TokenType):
         self.errors.append(Error(
             "UNEXPECTED TOKEN",
@@ -1439,3 +1457,5 @@ class Parser:
             token.position,
             token.end_position
         ))
+    def expected_exprs(self) -> list:
+        return self.expected_infix + [TokenType.INCREMENT_OPERATOR, TokenType.DECREMENT_OPERATOR]

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -1160,8 +1160,15 @@ class Parser:
                     return None
                 sf.exprs.append(res)
 
-            if self.expect_peek(TokenType.STRING_PART_MID):
-                sf.mid.append(self.curr_tok)
+            if not self.expect_peek(TokenType.STRING_PART_MID):
+                if self.peek_tok_is(TokenType.STRING_PART_END):
+                    sf.mid.append(self.curr_tok)
+                    continue
+                self.unclosed_string_part_error(self.peek_tok, sf.exprs, added = len(sf.mid) < len(sf.exprs))
+                self.advance(2)
+                return None
+            sf.mid.append(self.curr_tok)
+            
 
         if not self.expect_peek(TokenType.STRING_PART_END):
             self.unclosed_string_part_error(self.peek_tok, sf.exprs, added = len(sf.mid) < len(sf.exprs))

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -91,7 +91,7 @@ class StringFmt(Production):
         for val in self.mid_expr_iter():
             res += sprintln(val.string(), indent=indent+1)
         res += sprint(self.end.string(), indent=indent+1)
-        return res[:-1]
+        return res if res[-1] != '\n' else res[:-1]
     def mid_expr_iter(self):
         if self.exprs:
             yield self.exprs[0]


### PR DESCRIPTION
# overhaul of errors, now its mostly in the format of: Expected {list of expected tokens}, got {actual token}
## Examples
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/ddc68346-6e50-4322-9cb6-b9e4b5548b27)

It changes expected tokens when say an identifier has postfix operators for example, it removes the postfix operators from the expected list
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/3ec41f93-0f78-4b92-b661-cc1fb0d68c8c)

same goes for function calls and indexed ids

![image](https://github.com/Gidsss/UwUIDE/assets/146176671/dd592b2f-7133-4663-bc18-15c782c97a9e)
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/795de5e5-2b03-4ed2-a24a-553f9e3ee15d)
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/7e13fc49-1890-4389-a5ad-0e5868c9857f)
---
Some errors kept their headers but just more verbose on what its expecting this time
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/c47345c3-c76d-4107-8c89-a3740cf2e0d3)
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/150d143b-1d42-4dd4-bc07-dab7e142e60f)
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/53e51417-cdaf-4dac-abdf-e6a1119eee2c)
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/98a4a2ed-e68e-4bcf-ae7b-83828f3ed2fe)


Others
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/f0cb1f84-4c2a-4e17-81b6-e870a863323a)
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/39515e7a-6a86-47a3-b99b-011d59643848)
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/fc24d15f-4015-43fc-b8be-561f773791ac)

