### PR TITLE
Feat/class body parsing overhaul

### DIFF
--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -10,12 +10,12 @@ if __name__ == "__main__":
     cwass Class() [[
         a-chan = a~
         fwunc test-san() [[
-            a = a~
-            >.< a = Person()~
-            Person.a = a~
+            a = a + 1~
+            a = Person()~
             iwf (fax) [[
                 pwint("do something")~
             ]]
+            wetuwn({1+1, A(1,2,B(A())), B()})~
         ]]
     ]]
     """

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -5,17 +5,12 @@ from .error_handler import ErrorSrc
 if __name__ == "__main__":
     sc = """
     fwunc mainuwu-san() [[
-        a=a~
+        a(A(), B(), C(A(B())))~
     ]]
     cwass Class() [[
         a-chan = a~
         fwunc test-san() [[
-            a = a + 1~
-            a = Person()~
-            iwf (fax) [[
-                pwint("do something")~
-            ]]
-            wetuwn({1+1, A(1,2,B(A())), B()})~
+            a(A() a )~
         ]]
     ]]
     """

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -5,8 +5,18 @@ from .error_handler import ErrorSrc
 if __name__ == "__main__":
     sc = """
     fwunc mainuwu-san() [[
-        a = inpwt() nuww 3
-        >.<a = ("| | | |")~
+        a=a~
+    ]]
+    cwass Class() [[
+        a-chan = a~
+        fwunc test-san() [[
+            a = a~
+            >.< a = Person()~
+            Person.a = a~
+            iwf (fax) [[
+                pwint("do something")~
+            ]]
+        ]]
     ]]
     """
 

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -350,12 +350,17 @@ class Parser:
             return None
         self.advance() # consume the open paren
 
-        if (res := self.parse_expression(LOWEST)) is None:
-            return None
-        rs.expr = res
+        if self.curr_tok_is_class_name():
+            if (res := self.parse_class_ident()) is None:
+                return None
+            rs.expr = res
+        else:
+            if (res := self.parse_expression(LOWEST, cwass=True)) is None:
+                return None
+            rs.expr = res
 
         if not self.expect_peek(TokenType.CLOSE_PAREN):
-            self.expected_error([TokenType.CLOSE_PAREN, *self.error_context(rs.expr)])
+            self.peek_error(TokenType.CLOSE_PAREN)
             self.advance(2)
             return None
         if not self.expect_peek(TokenType.TERMINATOR):

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -1417,9 +1417,11 @@ class Parser:
             self.peek_tok.position,
             self.peek_tok.end_position
         ))
+    def no_prefix_parse_fn_error(self, token_type, special = False, cwass=False):
         msg = f"'{token_type}' is not a valid starting token for an expression"
         msg += f"\n\tExpected any of the ff:"
         tmp = self.expected_prefix+self.expected_prefix_special
+        tmp += ["CWASS_ID"] if cwass else []
         if special:
             tmp = self.expected_prefix_special
         for token in tmp[:-1]:
@@ -1670,11 +1672,12 @@ class Parser:
             token.position,
             token.end_position
         ))
-    def hanging_comma_error(self, token: Token):
+    def hanging_comma_error(self, token: Token, cwass=False):
         msg = f"Expected any of the ff:"
         for token in self.expected_prefix[:-1]:
             msg += f" '{token}',"
         msg += f" '{self.expected_prefix[-1]}'"
+        msg += f", 'CWASS_ID'" if cwass else ""
         msg += f"\n\tgot '{self.peek_tok}' instead"
         self.errors.append(Error(
             "HANGING COMMA",
@@ -1685,7 +1688,7 @@ class Parser:
 
     def expected_exprs(self) -> list:
         return self.expected_infix + [TokenType.INCREMENT_OPERATOR, TokenType.DECREMENT_OPERATOR]
-    def error_context(self, tok) -> list[TokenType]:
+    def error_context(self, tok, cwass=False) -> list[TokenType]:
         'error context for expression tokens'
         if isinstance(tok, list) and len(tok) == 0:
             return self.expected_prefix
@@ -1693,6 +1696,7 @@ class Parser:
             tok = tok[-1]
 
         added = {*self.expected_infix}
+        added.update({"CWASS_ID"} if cwass else {})
         # add/remove expected tokens based on passed token
         if not isinstance(tok, PostfixExpression):
             added.update({TokenType.OPEN_PAREN, TokenType.OPEN_BRACKET, TokenType.INCREMENT_OPERATOR, TokenType.DECREMENT_OPERATOR})

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -881,7 +881,7 @@ class Parser:
         return p
 
     ### expression parsers
-    def parse_expression(self, precedence, limit_to: list[TokenType] = [], grouped: bool = False):
+    def parse_expression(self, precedence, limit_to: list[TokenType] = [], grouped: bool = False, cwass=False):
         '''
         parse expressions.
         Expressions can be:
@@ -905,7 +905,7 @@ class Parser:
         if prefix is None:
             prefix = self.get_prefix_special_parse_fn(self.curr_tok.token)
             if prefix is None:
-                self.no_prefix_parse_fn_error(self.curr_tok.token)
+                self.no_prefix_parse_fn_error(self.curr_tok.token, cwass=cwass)
                 self.advance()
                 return None
             special = True

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -1300,10 +1300,16 @@ class Parser:
     def curr_tok_is_identifier(self) -> bool:
         '''
         checks if the next token is an identifier.
-        advances the cursor if it is.
-        cursor won't advance if not.
         '''
         if self.curr_tok.token.token.startswith("IDENTIFIER"):
+            return True
+        else:
+            return False
+    def curr_tok_is_class_name(self) -> bool:
+        '''
+        checks if the next token is an identifier.
+        '''
+        if self.curr_tok.token.token.startswith("CWASS"):
             return True
         else:
             return False
@@ -1312,10 +1318,16 @@ class Parser:
     def peek_tok_is_identifier(self) -> bool:
         '''
         checks if the next token is an identifier.
-        advances the cursor if it is.
-        cursor won't advance if not.
         '''
         if self.curr_tok.token.token.startswith("IDENTIFIER"):
+            return True
+        else:
+            return False
+    def peek_tok_is_class_name(self) -> bool:
+        '''
+        checks if the next token is an identifier.
+        '''
+        if self.curr_tok.token.token.startswith("CWASS"):
             return True
         else:
             return False
@@ -1405,7 +1417,6 @@ class Parser:
             self.peek_tok.position,
             self.peek_tok.end_position
         ))
-    def no_prefix_parse_fn_error(self, token_type, special = False):
         msg = f"'{token_type}' is not a valid starting token for an expression"
         msg += f"\n\tExpected any of the ff:"
         tmp = self.expected_prefix+self.expected_prefix_special

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -525,7 +525,7 @@ class Class(Production):
         self.id = None
         self.params: list = []
         self.body: BlockStatement = None
-        self.properties: list = []
+        self.properties: list[Declaration] = []
         self.methods: list = []
 
     def header(self):


### PR DESCRIPTION
closes #144 

## main changes
- in class body, only declarations are allowed. these are stored in the Cwass.property
- removed parsing class id statements since no declarations or assignments can start with a class id anymore
- class constructors are only allowed as:
  - return args
  - func args
  - array elems
  - _note: cannot be followed by any operator_

### minor changes:
- added helper methods to check if current/peek token is an identifier/class id
- various parsers take an optional `cwass` bool to know to expect a `cwass_id` when an error occurs, not necessarily expecting the `cwass_id` in the parsing itself