### PR TITLE
Feat/id parsing overhaul

### DIFF
--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -5,7 +5,7 @@ from .error_handler import ErrorSrc
 if __name__ == "__main__":
     sc = """
     fwunc mainuwu-san() [[
-        a[2].a.a.a[1].a[3].b.a.b()~
+        a[2].a.a.a[1].a[3].b.a.b() = 2~
         a = a[2].a().a.a[1].a[3].b~
     ]]
     """

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -5,7 +5,7 @@ from .error_handler import ErrorSrc
 if __name__ == "__main__":
     sc = """
     fwunc mainuwu-san() [[
-        a[2].a.a.a[1].a[3].b.a.b() = 2~
+        a[2].a()-chan~
         a = a[2].a().a.a[1].a[3].b~
     ]]
     """

--- a/src/parser/__main__.py
+++ b/src/parser/__main__.py
@@ -5,13 +5,8 @@ from .error_handler import ErrorSrc
 if __name__ == "__main__":
     sc = """
     fwunc mainuwu-san() [[
-        a(A(), B(), C(A(B())))~
-    ]]
-    cwass Class() [[
-        a-chan = a~
-        fwunc test-san() [[
-            a(A() a )~
-        ]]
+        a[2].a.a.a[1].a[3].b.a.b()~
+        a = a[2].a().a.a[1].a[3].b~
     ]]
     """
 

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -685,15 +685,14 @@ class Parser:
         # fn calls must ONLY be followed by a terminator
         tmp = res
         if isinstance(tmp, ClassAccessor):
+            # check if last accessed id is an fn call
             peek_tmp = tmp
-            while True:
+            while not isinstance(peek_tmp, Token):
+                tmp = peek_tmp
                 if isinstance(tmp, ClassAccessor):
                     peek_tmp = tmp.accessed
                 elif isinstance(tmp, IndexedIdentifier) or isinstance(tmp, FnCall):
                     peek_tmp = tmp.id
-                if isinstance(peek_tmp, Token):
-                    break
-                tmp = peek_tmp
         if isinstance(tmp, FnCall):
             if not self.expect_peek(TokenType.TERMINATOR):
                 self.peek_error(TokenType.TERMINATOR)
@@ -701,6 +700,7 @@ class Parser:
                 return None
             return res
 
+        # is an assignment cont.
         a.id = res
         if not self.expect_peek(TokenType.ASSIGNMENT_OPERATOR):
             if isinstance(a.id, IndexedIdentifier):


### PR DESCRIPTION
### changes
- declarations/assignments cannot have function calls anywhere in the identifier
  - `a.a.a = a~` valid
  - `a.a().a = a~` invalid
  - `a() = a~` invalid
- declarations cannot have indexing in the last accessed identifier
  - `a-chan = a~` valid
  - `a[1].a-chan = a~` valid
  - `a[1]-chan = a~` invalid
  - `a.a.a.a[1]-chan = a~` invalid
  - _note: assignments are fine having indexing in the last accessed identifier_
    - `a = a~` valid
    - `a[1].a = a~` valid
    - `a[1] = a~` valid
    - `a.a.a.a[1] = a~` valid
