### PR TITLE
Fix/class analyzer context

### DIFF
--- a/src/analyzer/__main__.py
+++ b/src/analyzer/__main__.py
@@ -9,23 +9,33 @@ from src.parser.error_handler import ErrorSrc as parErrorSrc
 if __name__ == "__main__":
     sc = """
     gwobaw areallylongname-kun-dono = 3.14~
+    cwass Hololive2(a-chan) [[
+        b-chan~
+        fwunc init-chan(c-chan) [[
+            b = inpwt(a[1].a() + a || b || "hello | b | world")~
+            sum(a, b)~
+        ]]
+    ]]
     cwass Hololive(a-chan) [[
         b-chan~
         fwunc init-chan(c-chan) [[
             b = inpwt(a[1].a() + a || b || "hello | b | world")~
+            sum(a, b)~
+            d-Hololive2 = Hololive2("2")~
         ]]
     ]]
     fwunc mainuwu-san() [[
-        a-Hololive = Hololive(2)~
-        b-Hololive = Hololive(3)~
-        c-senpai = a.b.init()~
-        d-chan[] = {{{{sum("2")}}}, "2", "f|3+3|", inpwt("4"), "5", {"6", {"1"}}}~
-        e-chan[] = {{{{a[1]}}}, "2", "f|3+3|", inpwt("4"), "5", {"6", {"1"}}}~
-        f-Hololive = sum()~
-        sum("-1++ + 1 + 1 > 10", 2)~
+        >.< a-Hololive = Hololive(2)~
+        >.< b-Hololive = Hololive(3)~
+        >.< c-senpai = a.b.init()~
+        >.< d-chan[] = {{{{sum("2")}}}, "2", "f|3+3|", inpwt("4"), "5", {"6", {"1"}}}~
+        >.< e-chan[] = {{{{a[1]}}}, "2", "f|3+3|", inpwt("4"), "5", {"6", {"1"}}}~
+        >.< f-Hololive = sum()~
+        >.< sum("-1++ + 1 + 1 > 10", 2)~
+        wetuwn(nuww)~
     ]]
     fwunc sum-chan(a-chan) [[
-        b-senpai[] = {Hololive(-a++ + a + a > 10)}~
+        >.< b-senpai[] = {Hololive(-a++ + a + a > 10)}~
         wetuwn(fax)~
     ]]
     """
@@ -61,7 +71,7 @@ if __name__ == "__main__":
 
     assert p.program
     for cwass in p.program.classes:
-        ca = ClassAnalyzer(cwass)
+        ca = ClassAnalyzer(cwass, ma.global_names)
         if ca.errors:
             for err in ca.errors:
                 print(err)

--- a/src/analyzer/__main__.py
+++ b/src/analyzer/__main__.py
@@ -12,31 +12,23 @@ if __name__ == "__main__":
     cwass Hololive2(a-chan) [[
         b-chan~
         fwunc init-chan(c-chan) [[
-            b = inpwt(a[1].a() + a || b || "hello | b | world")~
+            b = inpwt(sum[1].a() + a || b || "hello | b | world")~
             sum(a, b)~
         ]]
     ]]
     cwass Hololive(a-chan) [[
-        b-chan~
+        b-chan = sum(1)~
         fwunc init-chan(c-chan) [[
-            b = inpwt(a[1].a() + a || b || "hello | b | world")~
+            b = inpwt(a[1] + a || b || "hello | b | world")~
             sum(a, b)~
             d-Hololive2 = Hololive2("2")~
         ]]
     ]]
     fwunc mainuwu-san() [[
-        >.< a-Hololive = Hololive(2)~
-        >.< b-Hololive = Hololive(3)~
-        >.< c-senpai = a.b.init()~
-        >.< d-chan[] = {{{{sum("2")}}}, "2", "f|3+3|", inpwt("4"), "5", {"6", {"1"}}}~
-        >.< e-chan[] = {{{{a[1]}}}, "2", "f|3+3|", inpwt("4"), "5", {"6", {"1"}}}~
-        >.< f-Hololive = sum()~
-        >.< sum("-1++ + 1 + 1 > 10", 2)~
         wetuwn(nuww)~
     ]]
-    fwunc sum-chan(a-chan) [[
-        >.< b-senpai[] = {Hololive(-a++ + a + a > 10)}~
-        wetuwn(fax)~
+    fwunc sum-Hololive[](a-chan) [[
+        wetuwn({Hololive(1)})~
     ]]
     """
     source: list[str] = [line if line else '\n' for line in sc.split("\n")]

--- a/src/analyzer/class_analyzer.py
+++ b/src/analyzer/class_analyzer.py
@@ -3,12 +3,12 @@ from src.analyzer.error_handler import DuplicateDefinitionError, GlobalType, Und
 from src.parser.productions import *
 
 class ClassAnalyzer:
-    def __init__(self, cwass: Class) -> None:
+    def __init__(self, cwass: Class, global_defs: dict[str, tuple[Token, GlobalType]]) -> None:
         self.cwass: Class = cwass
         self.errors = []
         self.warnings = []
 
-        self.class_members: dict[str, tuple[Token, GlobalType]] = {}
+        self.class_members: dict[str, tuple[Token, GlobalType]] = global_defs.copy()
         self.compile_class_members()
         self.analyze_program()
 

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -313,6 +313,26 @@ class TypeChecker:
             case _:
                 raise ValueError(f"Unknown class accessor: {accessor}")
 
+    def extract_id(self, accessor: ClassAccessor) -> str:
+        'gets the very first id of a class accessor'
+        match accessor.id:
+            case Token():
+                return accessor.id.flat_string()
+            case FnCall():
+                return accessor.id.id.flat_string()
+            case IndexedIdentifier():
+                match accessor.id.id:
+                    case Token():
+                        return accessor.id.id.flat_string()
+                    case FnCall():
+                        return accessor.id.id.id.flat_string()
+                    case _:
+                        raise ValueError(f"Unknown class accessor: {accessor}")
+            case ClassAccessor():
+                return self.extract_id(accessor.id)
+            case _:
+                raise ValueError(f"Unknown class accessor: {accessor}")
+
     def evaluate_iterable(self, collection: Iterable, local_defs: dict[str, tuple[Token, GlobalType]]) -> TokenType:
         match collection:
             case ArrayLiteral():

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -47,7 +47,7 @@ class TypeChecker:
         assert self.program.mainuwu
         self.check_function(self.program.mainuwu, self.global_defs.copy())
         for func in self.program.functions: self.check_function(func, self.global_defs)
-        # for cwass in self.program.classes: self.check_class(cwass, self.global_defs.copy())
+        for cwass in self.program.classes: self.check_class(cwass, self.global_defs.copy())
 
     def check_function(self, func: Function, local_defs: dict[str, tuple[Token, GlobalType]]) -> None:
         'make sure you pass in a copy of local_defs when calling this'
@@ -56,7 +56,11 @@ class TypeChecker:
 
     def check_class(self, cwass: Class, local_defs: dict[str, tuple[Token, GlobalType]]) -> None:
         'make sure you pass in a copy of local_defs when calling this'
-        raise NotImplementedError
+        self.compile_params(cwass.params, local_defs)
+        for prop in cwass.properties:
+            self.check_declaration(prop, local_defs)
+        for method in cwass.methods:
+            self.check_function(method, local_defs)
 
     def compile_params(self, params: list[Parameter], local_defs: dict[str, tuple[Token, GlobalType]]) -> None:
         'make sure you pass in a copy of local_defs when calling this'

--- a/src/lexer/token.py
+++ b/src/lexer/token.py
@@ -1,6 +1,6 @@
 from constants.constants import DELIMS
 from enum import Enum
-
+from copy import copy, deepcopy
 
 class TokenType(Enum):
     def __init__(self, token: str, delim_id: str):
@@ -257,7 +257,7 @@ class Token:
         return self._lexeme
 
     def to_arr(self):
-        self._lexeme += "[]"
+        self._lexeme += "[]" if not self._lexeme.endswith("[]") else ""
         match self.token:
             case TokenType.CHAN:
                 self._token = TokenType.CHAN_ARR
@@ -275,19 +275,23 @@ class Token:
     def is_arr_type(self):
         return self.token.is_arr_type()
 
-    def to_unit(self):
-        self._lexeme = self._lexeme[:-2]
-        match self.token:
+    def to_unit_type(self):
+        ret = deepcopy(self)
+        ret._lexeme = self._lexeme[:-2] if self._lexeme.endswith("[]") else self._lexeme
+        match ret.token:
             case TokenType.CHAN_ARR:
-                self._token = TokenType.CHAN
+                ret._token = TokenType.CHAN
             case TokenType.KUN_ARR:
-                self._token = TokenType.KUN
+                ret._token = TokenType.KUN
             case TokenType.SAMA_ARR:
-                self._token = TokenType.SAMA
+                ret._token = TokenType.SAMA
             case TokenType.SAN_ARR:
-                self._token = TokenType.SAN
+                ret._token = TokenType.SAN
             case TokenType.SENPAI_ARR:
-                self._token = TokenType.SENPAI
+                ret._token = TokenType.SENPAI
+            case UniqueTokenType():
+                ret._token = ret._token.to_unit_type()
+        return ret
 
     @property
     def lexeme(self) -> str:

--- a/src/lexer/token.py
+++ b/src/lexer/token.py
@@ -269,6 +269,8 @@ class Token:
                 self._token = TokenType.SAN_ARR
             case TokenType.SENPAI:
                 self._token = TokenType.SENPAI_ARR
+            case UniqueTokenType():
+                self._token = self.token.to_arr_type()
 
     def is_arr_type(self):
         return self.token.is_arr_type()


### PR DESCRIPTION
# class analysis now has context of the global scope, fixed class accessor type checking, and more~
## sample text file
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/e647933b-3823-4456-b3b2-e54b05e6b269)

## result
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/7d153acf-8f98-4f18-882d-a7d1f5eb5f63)

_notice that the classes reference things outside of their respective classes and no errors in analysis (only in type checking which is fine)_

---

### changes
- class member analysis now has context of the global scope
- class arrays are now properly parsed
- ensure main accessor's id's type is a class in the first place before proceeding in type checking the accessed
- converting tokens into its unit type from array type (`chan[] --> chan`) now does a deep copy to avoid side effects