### PR TITLE
Feat/type check errors

### DIFF
--- a/src/analyzer/__main__.py
+++ b/src/analyzer/__main__.py
@@ -18,7 +18,8 @@ if __name__ == "__main__":
     ]]
     fwunc mainuwu-san() [[
         >.< e-Hololive2 = 10+10~
-        longname-chan~
+        longname-chan = "1"~
+        longname = "2"~
         f-Hololive2 = Hololive2(2,1,2,3,4)~
         longname = f.e[1]~
         longname = f.e()~
@@ -33,8 +34,14 @@ if __name__ == "__main__":
         tooMuch = sum("2","3", 1+1-1*1/1%1, "2", "2", "2", 1, 2, 3)~
         tooLess = f.sum("2","3", 1+1-1*1/1%1)~
         tooMuch = f.sum("2","3", 1+1-1*1/1%1, "2", "2", "2", 1, 2, 3)~
-        correct = sum(2,"3", 1+1-1*1/1%1, 2, 2, 2, 2)~
-        wetuwn(nuww)~
+        correct = sum(2,3, 1+1-1*1/1%1, 2, 2, 2, 2)~
+
+        i-chan-dono=tooMuch - tooLess~
+        i = 1~
+        fow(i=0~ i<10~ i+1) [[
+            pwint(i)~
+        ]]
+        wetuwn(fax)~
     ]]
     fwunc sum-senpai(d-chan, e-senpai, f-sama, g-chan, h-chan, i-chan, j-chan) [[
         wetuwn("d")~

--- a/src/analyzer/__main__.py
+++ b/src/analyzer/__main__.py
@@ -10,7 +10,7 @@ if __name__ == "__main__":
     cwass Hololive2(a-chan) [[
         c-senpai-dono = ""~
         e-Hololive2 = Hololive2(2)~
-        fwunc sum-chan(d-chan) [[
+        fwunc sum-chan(d-chan, k-senpai, f-sama, g-chan, h-chan, i-chan, l-chan) [[
             j-senpai[]~
             c = j.len()~
             c = j[1].has(1,2,3)~
@@ -26,11 +26,13 @@ if __name__ == "__main__":
         longname = f.undefined~
         longname = f.undefined()~
         longname = longname[1].a~
-        tooMuch-senpai~
+        tooMuch-senpai[] = {"1", {"2"}, {{"3"}}, {{{4}}}}~
         tooLess-senpai~
         correct-senpai~
         tooLess = sum("2","3", 1+1-1*1/1%1)~
         tooMuch = sum("2","3", 1+1-1*1/1%1, "2", "2", "2", 1, 2, 3)~
+        tooLess = f.sum("2","3", 1+1-1*1/1%1)~
+        tooMuch = f.sum("2","3", 1+1-1*1/1%1, "2", "2", "2", 1, 2, 3)~
         correct = sum(2,"3", 1+1-1*1/1%1, 2, 2, 2, 2)~
         wetuwn(nuww)~
     ]]

--- a/src/analyzer/__main__.py
+++ b/src/analyzer/__main__.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
     fwunc mainuwu-san() [[
         >.< e-Hololive2 = 10+10~
         longname-chan~
-        f-Hololive2 = Hololive2(2)~
+        f-Hololive2 = Hololive2(2,1,2,3,4)~
         longname = f.e[1]~
         longname = f.e()~
         longname = f.sum~

--- a/src/analyzer/__main__.py
+++ b/src/analyzer/__main__.py
@@ -26,10 +26,16 @@ if __name__ == "__main__":
         longname = f.undefined~
         longname = f.undefined()~
         longname = longname[1].a~
+        tooMuch-senpai~
+        tooLess-senpai~
+        correct-senpai~
+        tooLess = sum("2","3", 1+1-1*1/1%1)~
+        tooMuch = sum("2","3", 1+1-1*1/1%1, "2", "2", "2", 1, 2, 3)~
+        correct = sum(2,"3", 1+1-1*1/1%1, 2, 2, 2, 2)~
         wetuwn(nuww)~
     ]]
-    fwunc sum-senpai(d-chan) [[
-        wetuwn("d" || 1 + 2+ 3 *5*4/7 >= 10 && fax)~
+    fwunc sum-senpai(d-chan, e-senpai, f-sama, g-chan, h-chan, i-chan, j-chan) [[
+        wetuwn("d")~
     ]]
     """
     source: list[str] = [line if line else '\n' for line in sc.split("\n")]

--- a/src/analyzer/__main__.py
+++ b/src/analyzer/__main__.py
@@ -18,10 +18,11 @@ if __name__ == "__main__":
     ]]
     fwunc mainuwu-san() [[
         >.< e-Hololive2 = 10+10~
-        longname-chan[]~
+        longname-chan~
         i-chan-dono = longname<longname>-longname++~
         f-Hololive2 = Hololive2(2)~
         longname = f.e[1]~
+        longname = longname[1].a~
         i = 10~
         fow(i=0~ i > 10~ i + 1) [[
             pwint(i)~

--- a/src/analyzer/__main__.py
+++ b/src/analyzer/__main__.py
@@ -19,14 +19,13 @@ if __name__ == "__main__":
     fwunc mainuwu-san() [[
         >.< e-Hololive2 = 10+10~
         longname-chan~
-        i-chan-dono = longname<longname>-longname++~
         f-Hololive2 = Hololive2(2)~
         longname = f.e[1]~
+        longname = f.e()~
+        longname = f.sum~
+        longname = f.undefined~
+        longname = f.undefined()~
         longname = longname[1].a~
-        i = 10~
-        fow(i=0~ i > 10~ i + 1) [[
-            pwint(i)~
-        ]]
         wetuwn(nuww)~
     ]]
     fwunc sum-senpai(d-chan) [[

--- a/src/analyzer/__main__.py
+++ b/src/analyzer/__main__.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
     fwunc mainuwu-san() [[
         >.< e-Hololive2 = 10+10~
         longname-senpai~
-        i-chan-dono = longname+longname+-longname++~
+        i-chan-dono = longname<longname>-longname++~
         i = 10~
         fow(i=0~ i > 10~ i + 1) [[
             pwint(i)~

--- a/src/analyzer/__main__.py
+++ b/src/analyzer/__main__.py
@@ -17,8 +17,9 @@ if __name__ == "__main__":
         ]]
     ]]
     fwunc mainuwu-san() [[
-        e-Hololive2 = 10+10~
-        i-senpai-dono = 10+10*10/10%10~
+        >.< e-Hololive2 = 10+10~
+        longname-senpai~
+        i-chan-dono = longname+longname+-longname~
         i = 10~
         fow(i=0~ i > 10~ i + 1) [[
             pwint(i)~

--- a/src/analyzer/__main__.py
+++ b/src/analyzer/__main__.py
@@ -18,8 +18,10 @@ if __name__ == "__main__":
     ]]
     fwunc mainuwu-san() [[
         >.< e-Hololive2 = 10+10~
-        longname-senpai~
+        longname-chan[]~
         i-chan-dono = longname<longname>-longname++~
+        f-Hololive2 = Hololive2(2)~
+        longname = f.e[1]~
         i = 10~
         fow(i=0~ i > 10~ i + 1) [[
             pwint(i)~

--- a/src/analyzer/__main__.py
+++ b/src/analyzer/__main__.py
@@ -9,13 +9,7 @@ if __name__ == "__main__":
     sc = """
     cwass Hololive2(a-chan) [[
         c-senpai-dono = ""~
-        e-Hololive = Hololive(2)~
-        fwunc sum-chan(d-chan) [[
-            c-chan = 10~
-            j-senpai[]~
-            c = j.len()~
-            c = j[1].has(1,2,3)~
-        ]]
+        e-Hololive2 = Hololive2(2)~
         fwunc sum-chan(d-chan) [[
             j-senpai[]~
             c = j.len()~
@@ -23,15 +17,16 @@ if __name__ == "__main__":
         ]]
     ]]
     fwunc mainuwu-san() [[
-        >.< e-Hololive = Hololive(2)~
-        i-senpai-dono = ""~
+        e-Hololive2 = 10+10~
+        i-senpai-dono = 10+10*10/10%10~
+        i = 10~
         fow(i=0~ i > 10~ i + 1) [[
             pwint(i)~
         ]]
         wetuwn(nuww)~
     ]]
-    fwunc sum-chan(d-chan) [[
-        wetuwn(d)~
+    fwunc sum-senpai(d-chan) [[
+        wetuwn("d" || 1 + 2+ 3 *5*4/7 >= 10 && fax)~
     ]]
     """
     source: list[str] = [line if line else '\n' for line in sc.split("\n")]

--- a/src/analyzer/__main__.py
+++ b/src/analyzer/__main__.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
         longname = f.undefined~
         longname = f.undefined()~
         longname = longname[1].a~
-        tooMuch-senpai[] = {"1", {"2"}, {{"3"}}, {{{4}}}}~
+        tooMuch-senpai[] = {"1", {fax}, {{Hololive2(2)}}, {{{4}}}}~
         tooLess-senpai~
         correct-senpai~
         tooLess = sum("2","3", 1+1-1*1/1%1)~

--- a/src/analyzer/__main__.py
+++ b/src/analyzer/__main__.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
     fwunc mainuwu-san() [[
         >.< e-Hololive2 = 10+10~
         longname-senpai~
-        i-chan-dono = longname+longname+-longname~
+        i-chan-dono = longname+longname+-longname++~
         i = 10~
         fow(i=0~ i > 10~ i + 1) [[
             pwint(i)~

--- a/src/analyzer/analyzer.py
+++ b/src/analyzer/analyzer.py
@@ -162,7 +162,7 @@ class MemberAnalyzer:
             case TokenType():
                 pass
             case UniqueTokenType():
-                self.expect_defined_token(decl.dtype, GlobalType.CLASS, local_defs)
+                self.expect_defined_token(decl.dtype.to_unit_type(), GlobalType.CLASS, local_defs)
             case _:
                 raise ValueError(f"Unknown dtype: {decl.dtype}")
         self.analyze_value(decl.value, local_defs)

--- a/src/analyzer/error_handler.py
+++ b/src/analyzer/error_handler.py
@@ -542,19 +542,20 @@ class HeterogeneousArrayError:
         msg += f"\t{' ' * max_pad} |\n"
         curr_type = None
         max_type_pad = max(len(dtype.token) for dtype in set(self.types))
+        colors = AnsiColor.colors_iter()
         for val, dtype in zip(self.vals, self.types):
             msg += f"\t{' ' * max_pad} |\t"
             if curr_type is None:
                 curr_type = dtype
                 msg += Styled.sprint(
                     f"{dtype.token:{max_type_pad}}",
-                    color=AnsiColor.RED
+                    color=next(colors)
                 )
             elif curr_type != dtype:
                 curr_type = dtype
                 msg += Styled.sprint(
                     f"{dtype.token:{max_type_pad}}",
-                    color=AnsiColor.RED
+                    color=next(colors)
                 )
             msg += Styled.sprintln(
                 f"\t{val.flat_string():{max_type_pad}}",

--- a/src/analyzer/error_handler.py
+++ b/src/analyzer/error_handler.py
@@ -93,7 +93,8 @@ class GenericTwoTokenError:
         index_str = str(self.token.position[0] + 1)
         defined_index = str(self.defined_token.position[0] + 1)
         max_pad = max(len(index_str), len(defined_index))
-        border = f"\t{'_' * (len(ErrorSrc.src[self.token.position[0]]) + len(str(self.token.position[0] + 1)) + max_pad)}\n"
+        max_len = len(max(ErrorSrc.src[self.token.position[0]], ErrorSrc.src[self.defined_token.position[0]], key=len))
+        border = f"\t{'_' * (max_len + max_pad + 4)}\n"
         defined_range = 1 if self.defined_token.end_position is None else self.defined_token.end_position[1] - self.defined_token.position[1] + 1
         error_range = 1 if self.token.end_position is None else self.token.end_position[1] - self.token.position[1] + 1
 
@@ -192,5 +193,40 @@ class TypeMismatchError:
         msg += f"\t{' ' * max_pad} | |{' ' * 4}{'^' * (len(self.actual_val.flat_string()))}\n"
         msg += f"\t{' ' * max_pad} | |{'_' * 4}|\n"
 
+        msg += border
+        return msg
+
+class PrefixOperandError:
+    def __init__(self, negative_op: Token, val: Value, val_definition: Token, val_type: TokenType) -> None:
+        self.negative_op = negative_op
+        self.val = val
+        self.val_definition = val_definition
+        self.val_type = val_type
+
+    def __str__(self):
+        op_index = str(self.negative_op.position[0] + 1)
+        def_index = str(self.val_definition.position[0] + 1)
+        max_pad = max(len(op_index), len(def_index))
+        border = f"\t{'_' * (len(self.val.flat_string()) + 7 + max_pad)}\n"
+        msg = f"Negative Non-Math Operand: '{self.val.flat_string()}'\n"
+        msg += border
+
+        msg += f"\t{' ' * max_pad} | \t"
+        msg += Styled.sprintln(
+            f"Expected type defined here",
+            color=AnsiColor.RED
+        )
+        msg += f"\t{def_index:{max_pad}} | {ErrorSrc.src[self.val_definition.position[0]]}\n"
+        msg += f"\t{' ' * max_pad} | {' ' * self.val_definition.position[1]}{'^' * (len(self.val_definition.flat_string()))}\n"
+        msg += f"\t{' ' * max_pad} | {'_' * (self.val_definition.position[1])}|\n"
+        msg += f"\t{' ' * max_pad} | |\t"
+
+        msg += Styled.sprintln(
+            f"Value below evaluates to type: '{self.val_type.flat_string()}'",
+            color=AnsiColor.RED
+        )
+        msg += f"\t{op_index:{max_pad}} | |  -{self.val.flat_string()}\n"
+        msg += f"\t{' ' * max_pad} | |{' ' * 3}{'^' * (len(self.val.flat_string()))}\n"
+        msg += f"\t{' ' * max_pad} | |{'_' * 3}|\n"
         msg += border
         return msg

--- a/src/analyzer/error_handler.py
+++ b/src/analyzer/error_handler.py
@@ -224,8 +224,8 @@ class PrePostFixOperandError:
             msg += f"\t{def_index:{max_pad}} | {ErrorSrc.src[self.val_definition.position[0]]}\n"
             msg += f"\t{' ' * max_pad} | {' ' * self.val_definition.position[1]}{'^' * (len(self.val_definition.flat_string()))}\n"
             msg += f"\t{' ' * max_pad} | {'_' * (self.val_definition.position[1])}|\n"
-            msg += f"\t{' ' * max_pad} | |\t"
 
+        msg += f"\t{' ' * max_pad} | " f"{'|' if self.val_definition else ''}" "\t"
         msg += Styled.sprintln(
             f"Value below evaluates to type: '{self.val_type.flat_string()}'",
             color=AnsiColor.RED
@@ -240,12 +240,14 @@ class PrePostFixOperandError:
 class InfixOperandError:
     def __init__(self, op: Token, left: tuple[Value, Token|None], 
                  right: tuple[Value, Token|None],
-                 left_type: TokenType|None, right_type: TokenType|None) -> None:
+                 left_type: TokenType|None, right_type: TokenType|None,
+                 header: str) -> None:
         self.op = op
         self.left, self.left_definition = left
         self.right, self.right_definition = right
         self.left_type = left_type
         self.right_type = right_type
+        self.header = header
 
     def __str__(self):
         op_str = str(self.op.position[0] + 1)
@@ -258,7 +260,7 @@ class InfixOperandError:
         border = f"\t{'_' * (max_len + max_pad)}"
 
         q = "'" # because f-strings lmao
-        msg = (f"Non-Math Infix Operand: "
+        msg = (self.header +
                f'{(q + self.left.flat_string() + q + " ") if self.left_type else ""}'
                f'{(q + self.right.flat_string() + q) if self.right_type else ""}'
                "\n")

--- a/src/analyzer/error_handler.py
+++ b/src/analyzer/error_handler.py
@@ -1,6 +1,6 @@
 from enum import Enum
 import re
-from src.parser.productions import ReturnStatement, Value
+from src.parser.productions import ArrayLiteral, ReturnStatement, Value
 from src.lexer.token import Token, TokenType
 from src.style import AnsiColor, Styled
 
@@ -519,3 +519,47 @@ class MismatchedCallArgType:
                     )
         msg += border
         return msg
+
+class HeterogeneousArrayError:
+    def __init__(self, arr: ArrayLiteral, vals: list[Value], types: list[TokenType]):
+        self.arr = arr
+        self.vals = vals
+        self.types = types
+
+    def __str__(self):
+        max_pad = 3
+        max_len = max(len(val.flat_string()) for val in self.vals)
+        border = f"\t{'_' * (max_len + 3 + max_pad)}\n"
+
+        msg = f"Heterogeneous Array:\n"
+        msg += border
+        msg += f"\t{' ' * max_pad} | \t"
+        msg += Styled.sprintln(
+            f"Array contains {len(set(self.types))} unit types: {', '.join([t.token for t in set(self.types)])}",
+            color=AnsiColor.RED
+        )
+        msg += f"\t{' ' * max_pad} | {self.arr.flat_string()}\n"
+
+        msg += f"\t{' ' * max_pad} |\n"
+        curr_type = None
+        max_type_pad = max(len(dtype.token) for dtype in set(self.types))
+        for val, dtype in zip(self.vals, self.types):
+            msg += f"\t{' ' * max_pad} |\t"
+            if curr_type is None:
+                curr_type = dtype
+                msg += Styled.sprint(
+                    f"{dtype.token:{max_type_pad}}",
+                    color=AnsiColor.RED
+                )
+            elif curr_type != dtype:
+                curr_type = dtype
+                msg += Styled.sprint(
+                    f"{dtype.token:{max_type_pad}}",
+                    color=AnsiColor.RED
+                )
+            msg += Styled.sprintln(
+                f"\t{val.flat_string():{max_type_pad}}",
+            )
+        msg += border
+        return msg
+

--- a/src/analyzer/error_handler.py
+++ b/src/analyzer/error_handler.py
@@ -315,3 +315,40 @@ class InfixOperandError:
                 msg += '\n'
         msg += border + '\n'
         return msg
+
+class ArrayAccessError:
+    def __init__(self, token: Token, type_definition: Token, token_type: TokenType) -> None:
+        self.token = token
+        self.type_definition = type_definition
+        self.token_type = token_type
+
+    def __str__(self):
+        tok_index = str(self.token.position[0] + 1)
+        def_index = str(self.type_definition.position[0] + 1)
+        max_pad = max(len(tok_index), len(def_index))
+        max_len = max(len(ErrorSrc.src[self.token.position[0]]), len(ErrorSrc.src[self.type_definition.position[0]]))
+        border = f"\t{'_' * (max_len + 3 + max_pad)}\n"
+
+        msg = f"Invalid Access:\n"
+        msg += border
+        msg += f"\t{' ' * max_pad} | \t"
+        msg += Styled.sprintln(
+            f"Actual type defined here",
+            color=AnsiColor.RED
+        )
+        msg += f"\t{def_index:{max_pad}} | {ErrorSrc.src[self.type_definition.position[0]]}\n"
+        msg += f"\t{' ' * max_pad} | {' ' * self.type_definition.position[1]}{'^' * (len(self.type_definition.flat_string()))}\n"
+        msg += f"\t{' ' * max_pad} | {'_' * (self.type_definition.position[1])}|\n"
+
+        msg += f"\t{' ' * max_pad} | |\n"
+        msg += f"\t{' ' * max_pad} | |\t"
+        msg += Styled.sprintln(
+            f"Tried to access a non iterable of type: '{self.token_type}'",
+            color=AnsiColor.RED
+        )
+        msg += f"\t{tok_index:{max_pad}} | |{ErrorSrc.src[self.token.position[0]]}\n"
+        msg += f"\t{' ' * max_pad} | |{' ' * self.token.position[1]}{'^' * (len(self.token.flat_string()))}\n"
+        msg += f"\t{' ' * max_pad} | |{'_' * (self.token.position[1])}|\n"
+
+        msg += border
+        return msg

--- a/src/analyzer/error_handler.py
+++ b/src/analyzer/error_handler.py
@@ -40,7 +40,7 @@ class DuplicateDefinitionError:
         msg += f"\t{' ' * max_pad} | \t"
         msg += Styled.sprintln(
             f'Original {self.original_type} definition',
-            color=AnsiColor.RED)
+            color=AnsiColor.GREEN)
         msg += f"\t{index_str:{max_pad}} | {ErrorSrc.src[self.original.position[0]]}\n"
         msg += f"\t{' ' * max_pad} | {' ' * self.original.position[1]}{'^' * (og_range)}\n"
         msg += f"\t{' ' * max_pad} | {'_' * (self.original.position[1])}|\n"
@@ -102,7 +102,7 @@ class ReassignedConstantError:
         msg += f"\t{' ' * max_pad} | \t"
         msg += Styled.sprintln(
             "Defined as constant here",
-            color=AnsiColor.RED
+            color=AnsiColor.GREEN
         )
         msg += f"\t{defined_index:{max_pad}} | {ErrorSrc.src[self.defined_token.position[0]]}\n"
         msg += f"\t{' ' * max_pad} | {' ' * self.defined_token.position[1]}{'^' * (defined_range)}\n"
@@ -122,11 +122,10 @@ class ReassignedConstantError:
         return msg
 
 class ReturnTypeMismatchError:
-    def __init__(self, expected: Token, return_stmt: ReturnStatement, actual_type: TokenType, expected_msg: str) -> None:
+    def __init__(self, expected: Token, return_stmt: ReturnStatement, actual_type: TokenType) -> None:
         self.expected = expected
         self.return_stmt = return_stmt
         self.actual_type = actual_type
-        self.expected_msg = expected_msg
 
     def __str__(self):
         expected_index = str(self.expected.position[0] + 1)
@@ -140,8 +139,8 @@ class ReturnTypeMismatchError:
 
         msg += f"\t{' ' * max_pad} | \t"
         msg += Styled.sprintln(
-            self.expected_msg,
-            color=AnsiColor.RED
+            f"Expected return type: '{self.expected}'",
+            color=AnsiColor.GREEN,
         )
         msg += f"\t{expected_index:{max_pad}} | {ErrorSrc.src[self.expected.position[0]]}\n"
         msg += f"\t{' ' * max_pad} | {' ' * self.expected.position[1]}{'^' * (len(self.expected.flat_string()))}\n"
@@ -178,7 +177,7 @@ class TypeMismatchError:
         msg += f"\t{' ' * max_pad} | \t"
         msg += Styled.sprintln(
             f"Expected type defined here",
-            color=AnsiColor.RED
+            color=AnsiColor.GREEN,
         )
         msg += f"\t{index_str:{max_pad}} | {ErrorSrc.src[self.expected.position[0]]}\n"
         msg += f"\t{' ' * max_pad} | {' ' * self.expected.position[1]}{'^' * (len(self.expected.flat_string()))}\n"
@@ -219,7 +218,7 @@ class PrePostFixOperandError:
             msg += f"\t{' ' * max_pad} | \t"
             msg += Styled.sprintln(
                 f"Expected type defined here",
-                color=AnsiColor.RED
+                color=AnsiColor.GREEN,
             )
             msg += f"\t{def_index:{max_pad}} | {ErrorSrc.src[self.val_definition.position[0]]}\n"
             msg += f"\t{' ' * max_pad} | {' ' * self.val_definition.position[1]}{'^' * (len(self.val_definition.flat_string()))}\n"
@@ -270,7 +269,7 @@ class InfixOperandError:
             msg += f"\n\t{' ' * max_pad} | \t"
             msg += Styled.sprintln(
                 f"Left hand side defined here",
-                color=AnsiColor.RED
+                color=AnsiColor.GREEN,
             )
             msg += f"\t{lhs_index:{max_pad}} | {ErrorSrc.src[self.left_definition.position[0]]}\n"
             msg += f"\t{' ' * max_pad} | {' ' * self.left_definition.position[1]}{'^' * (len(self.left_definition.flat_string()))}\n"
@@ -295,7 +294,7 @@ class InfixOperandError:
             msg += f"\n\t{' ' * max_pad} | \t"
             msg += Styled.sprintln(
                 f"Right hand side defined here",
-                color=AnsiColor.RED
+                color=AnsiColor.GREEN,
             )
             msg += f"\t{rhs_index:{max_pad}} | {ErrorSrc.src[self.right_definition.position[0]]}\n"
             msg += f"\t{' ' * max_pad} | {' ' * self.right_definition.position[1]}{'^' * (len(self.right_definition.flat_string()))}\n"
@@ -335,7 +334,7 @@ class NonIterableIndexingError:
         msg += f"\t{' ' * max_pad} | \t"
         msg += Styled.sprintln(
             f"Actual type defined here",
-            color=AnsiColor.RED
+            color=AnsiColor.GREEN,
         )
         msg += f"\t{def_index:{max_pad}} | {ErrorSrc.src[self.type_definition.position[0]]}\n"
         msg += f"\t{' ' * max_pad} | {' ' * self.type_definition.position[1]}{'^' * (len(self.type_definition.flat_string()))}\n"
@@ -373,7 +372,7 @@ class NonClassAccessError:
             msg += f"\t{' ' * max_pad} | \t"
             msg += Styled.sprintln(
                 f"Actual type defined here",
-                color=AnsiColor.RED
+                color=AnsiColor.GREEN,
             )
             msg += f"\t{def_index:{max_pad}} | {ErrorSrc.src[self.id_definition.position[0]]}\n"
             msg += f"\t{' ' * max_pad} | {' ' * self.id_definition.position[1]}{'^' * (len(self.id_definition.flat_string()))}\n"
@@ -414,7 +413,7 @@ class UndefinedClassMember:
             msg += f"\t{' ' * max_pad} |\t"
             msg += Styled.sprintln(
                 f"'{self.property.flat_string()}' is a {self.actual_type} of '{self.cwass}' defined here",
-                color=AnsiColor.RED
+                color=AnsiColor.GREEN,
             )
             msg += f"\t{str(self.actual_definition.position[0] + 1):{max_pad}} | {ErrorSrc.src[self.actual_definition.position[0]]}\n"
             msg += f"\t{' ' * max_pad} | {' ' * self.actual_definition.position[1]}{'^' * (len(self.actual_definition.flat_string()))}\n"
@@ -457,7 +456,7 @@ class MismatchedCallArgType:
         msg += f"\t{' ' * max_pad} |\t"
         msg += Styled.sprintln(
             f"'{self.call_str}()' {self.global_type} defined here",
-            color=AnsiColor.RED
+            color=AnsiColor.GREEN,
         )
         msg += f"\t{def_index:{max_pad}} | {ErrorSrc.src[self.id_definition.position[0]]}\n"
         msg += f"\t{' ' * max_pad} | {' ' * self.id_definition.position[1]}{'^' * (len(self.id_definition.flat_string()))}\n"
@@ -537,7 +536,7 @@ class HeterogeneousArrayError:
             f"Array contains {len(set(self.types))} unit types: {', '.join([t.token for t in set(self.types)])}",
             color=AnsiColor.RED
         )
-        msg += f"\t{' ' * max_pad} | {self.arr.flat_string()}\n"
+        msg += f"\t{' ' * max_pad} | \t{self.arr.flat_string()}\n"
 
         msg += f"\t{' ' * max_pad} |\n"
         curr_type = None

--- a/src/analyzer/error_handler.py
+++ b/src/analyzer/error_handler.py
@@ -230,3 +230,81 @@ class PrefixOperandError:
         msg += f"\t{' ' * max_pad} | |{'_' * 3}|\n"
         msg += border
         return msg
+
+class InfixOperandError:
+    def __init__(self, op: Token, left: tuple[Value, Token|None], 
+                 right: tuple[Value, Token|None],
+                 left_type: TokenType|None, right_type: TokenType|None) -> None:
+        self.op = op
+        self.left, self.left_definition = left
+        self.right, self.right_definition = right
+        self.left_type = left_type
+        self.right_type = right_type
+
+    def __str__(self):
+        op_str = str(self.op.position[0] + 1)
+        expr_len = len(self.left.flat_string()) + len(self.op.flat_string()) + len(self.right.flat_string())
+        left_def_len = len(ErrorSrc.src[self.left_definition.position[0]]) if self.left_definition else 0
+        right_def_len = len(ErrorSrc.src[self.right_definition.position[0]]) if self.right_definition else 0
+        max_len = max(expr_len, left_def_len, right_def_len)
+        max_pad = max(len(op_str), len(str(self.left_definition.position[0])) if self.left_definition else 0,
+                      len(str(self.right_definition.position[0])) if self.right_definition else 0)
+        border = f"\t{'_' * (max_len + 3 + max_pad)}"
+
+        q = "'" # because f-strings lmao
+        msg = (f"Non-Math Infix Operand: "
+               f'{(q + self.left.flat_string() + q + " ") if self.left_type else ""}'
+               f'{(q + self.right.flat_string() + q) if self.right_type else ""}'
+               "\n")
+        msg += border
+        if self.left_definition:
+            lhs_index = str(self.left_definition.position[0] + 1)
+            msg += f"\n\t{' ' * max_pad} | \t"
+            msg += Styled.sprintln(
+                f"Left hand side defined here",
+                color=AnsiColor.RED
+            )
+            msg += f"\t{lhs_index:{max_pad}} | {ErrorSrc.src[self.left_definition.position[0]]}\n"
+            msg += f"\t{' ' * max_pad} | {' ' * self.left_definition.position[1]}{'^' * (len(self.left_definition.flat_string()))}\n"
+            msg += f"\t{' ' * max_pad} | {'_' * (self.left_definition.position[1])}|\n"
+            msg += f"\t{' ' * max_pad} | |"
+        if self.left_type:
+            msg += f"\n\t{' ' * max_pad} | "f"{'|' if self.left_definition else ''}""\t"
+            msg += Styled.sprintln(
+                f"Value below evaluates to type: '{self.left_type.flat_string()}'",
+                color=AnsiColor.RED
+            )
+            msg += f"\t{op_str:{max_pad}} | " f"{'|' if self.left_definition else ''}" f"  {self.left.flat_string()}{self.op.flat_string()}{self.right.flat_string()}\n"
+            msg += f"\t{' ' * max_pad} | " f"{'|' if self.left_definition else ''}" f"  {'^' * (len(self.left.flat_string()))}"
+            if self.left_definition:
+                msg += f"\n\t{' ' * max_pad} | |__|\n"
+            else:
+                msg += '\n'
+        if self.left_type and self.right_type:
+            msg += f"\t{' ' * max_pad} |"
+        if self.right_definition:
+            rhs_index = str(self.right_definition.position[0] + 1)
+            msg += f"\n\t{' ' * max_pad} | \t"
+            msg += Styled.sprintln(
+                f"Right hand side defined here",
+                color=AnsiColor.RED
+            )
+            msg += f"\t{rhs_index:{max_pad}} | {ErrorSrc.src[self.right_definition.position[0]]}\n"
+            msg += f"\t{' ' * max_pad} | {' ' * self.right_definition.position[1]}{'^' * (len(self.right_definition.flat_string()))}\n"
+            msg += f"\t{' ' * max_pad} | {'_' * (self.right_definition.position[1])}|\n"
+            msg += f"\t{' ' * max_pad} | |"
+        if self.right_type:
+            msg += f"\n\t{' ' * max_pad} | " f"{'|' if self.right_definition else ''}" "\t"
+            msg += Styled.sprintln(
+                f"Value below evaluates to type: '{self.right_type.flat_string()}'",
+                color=AnsiColor.RED
+            )
+            msg += f"\t{op_str:{max_pad}} | " f"{'|' if self.right_definition else ''}" f"  {self.left.flat_string()}{self.op.flat_string()}{self.right.flat_string()}\n"
+            msg += f"\t{' ' * max_pad} | " f"{'|' if self.right_definition else ''}" f"  {' ' * (len(self.left.flat_string()) + len(self.op.flat_string()))}{'^' * (len(self.right.flat_string()))}"
+            if self.right_definition:
+                msg += f"\n\t{' ' * max_pad} | |__"f"{'_' * (1+len(self.left.flat_string()))}|\n"
+            else:
+                msg += '\n'
+        msg += border + '\n'
+        return msg
+

--- a/src/analyzer/error_handler.py
+++ b/src/analyzer/error_handler.py
@@ -451,7 +451,7 @@ class MismatchedCallArgType:
         id_index = str(self.id.position[0] + 1)
         def_index = str(self.id_definition.position[0] + 1)
         max_pad = max(len(id_index), len(def_index))
-        border = f"\t{'_' * (max_pad + 4 + max([len(arg.flat_string()) for arg in self.args]))}\n"
+        border = f"\t{'_' * (max_pad + 4 + max([len(arg.flat_string()) for arg in self.args] + [len(ErrorSrc.src[self.id.position[0]]), len(ErrorSrc.src[self.id_definition.position[0]])]))}\n"
 
         msg = f"Call arg type mismatch:\n"
         msg += border
@@ -477,7 +477,7 @@ class MismatchedCallArgType:
         msg += f"\t{' ' * max_pad} |\t"
 
         msg += Styled.sprintln(
-            f"'{self.call_str}()' {self.global_type} expects {len(self.expected_types)} arguments"+
+            f"'{self.call_str}()' {self.global_type} expects {len(self.expected_types)} {'argument' if len(self.expected_types) == 1 else 'arguments'}"+
             (f" but was called with {len(self.args)}" if len(self.expected_types) != len(self.actual_types) else ""),
             color=AnsiColor.CYAN
         )

--- a/src/analyzer/error_handler.py
+++ b/src/analyzer/error_handler.py
@@ -120,3 +120,42 @@ class GenericTwoTokenError:
         msg += border
 
         return msg
+
+class ReturnTypeMismatchError:
+    def __init__(self, expected: Token, return_stmt: ReturnStatement, actual_type: TokenType, expected_msg: str) -> None:
+        self.expected = expected
+        self.return_stmt = return_stmt
+        self.actual_type = actual_type
+        self.expected_msg = expected_msg
+
+    def __str__(self):
+        expected_index = str(self.expected.position[0] + 1)
+        max_pad = max(len(expected_index), 3)
+        expected_pad = len(ErrorSrc.src[self.expected.position[0]]) + max_pad + 3
+        actual_pad = 17 + len(self.return_stmt.expr.flat_string()) + max_pad
+        border = f"\t{'_' * max(expected_pad, actual_pad)}\n"
+
+        msg = f"Return Type Mismatch: expected '{self.expected.flat_string()}' but got '{self.actual_type.flat_string()}'\n"
+        msg += border
+
+        msg += f"\t{' ' * max_pad} | \t"
+        msg += Styled.sprintln(
+            self.expected_msg,
+            color=AnsiColor.RED
+        )
+        msg += f"\t{expected_index:{max_pad}} | {ErrorSrc.src[self.expected.position[0]]}\n"
+        msg += f"\t{' ' * max_pad} | {' ' * self.expected.position[1]}{'^' * (len(self.expected.flat_string()))}\n"
+        msg += f"\t{' ' * max_pad} | {'_' * (self.expected.position[1])}|\n"
+        msg += f"\t{' ' * max_pad} | |\n"
+
+        msg += f"\t{' ' * max_pad} | |\t"
+        msg += Styled.sprintln(
+            f"Value below evaluates to type: '{self.actual_type.flat_string()}'",
+            color=AnsiColor.RED
+        )
+        msg += f"\t{'ret':{max_pad}} | |    wetuwn({self.return_stmt.expr.flat_string()})~\n"
+        msg += f"\t{' ' * max_pad} | |{' ' * 11}{'^' * (len(self.return_stmt.expr.flat_string()))}\n"
+        msg += f"\t{' ' * max_pad} | |{'_' * 11}|\n"
+
+        msg += border
+        return msg

--- a/src/analyzer/error_handler.py
+++ b/src/analyzer/error_handler.py
@@ -159,3 +159,38 @@ class ReturnTypeMismatchError:
 
         msg += border
         return msg
+
+class TypeMismatchError:
+    def __init__(self, expected: Token, actual_val: Value, actual_type: TokenType) -> None:
+        self.expected = expected
+        self.actual_val = actual_val
+        self.actual_type = actual_type
+
+    def __str__(self):
+        index_str = str(self.expected.position[0] + 1)
+        max_pad = max(len(index_str), 3)
+        border = f"\t{'_' * (len(ErrorSrc.src[self.expected.position[0]]) + len(str(self.expected.position[0] + 1)) + max_pad)}\n"
+
+        msg = f"Type Mismatch: expected '{self.expected.flat_string()}' but got '{self.actual_type.flat_string()}'\n"
+        msg += border
+
+        msg += f"\t{' ' * max_pad} | \t"
+        msg += Styled.sprintln(
+            f"Expected type defined here",
+            color=AnsiColor.RED
+        )
+        msg += f"\t{index_str:{max_pad}} | {ErrorSrc.src[self.expected.position[0]]}\n"
+        msg += f"\t{' ' * max_pad} | {' ' * self.expected.position[1]}{'^' * (len(self.expected.flat_string()))}\n"
+        msg += f"\t{' ' * max_pad} | {'_' * (self.expected.position[1])}|\n"
+
+        msg += f"\t{' ' * max_pad} | |\t"
+        msg += Styled.sprintln(
+            f"Tried to assign a value that evaluates to type: '{self.actual_type.flat_string()}'",
+            color=AnsiColor.RED
+        )
+        msg += f"\t{'rhs':{max_pad}} | |    {self.actual_val.flat_string()}\n"
+        msg += f"\t{' ' * max_pad} | |{' ' * 4}{'^' * (len(self.actual_val.flat_string()))}\n"
+        msg += f"\t{' ' * max_pad} | |{'_' * 4}|\n"
+
+        msg += border
+        return msg

--- a/src/analyzer/error_handler.py
+++ b/src/analyzer/error_handler.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from src.parser.productions import ClassAccessor, FnCall, IndexedIdentifier, Value
+from src.parser.productions import ClassAccessor, FnCall, IndexedIdentifier, ReturnStatement, Value
 from src.lexer.token import Token, TokenType
 from src.style import AnsiColor, Styled
 
@@ -77,4 +77,46 @@ class UndefinedError:
         msg += f"\t{index_str:{max_pad}} | {ErrorSrc.src[self.token.position[0]]}\n"
         msg += f"\t{' ' * max_pad} | {' ' * self.token.position[1]}{'^' * (error_range)}\n"
         msg += border
+        return msg
+
+class GenericTwoTokenError:
+    'errors that include two tokens'
+    def __init__(self, token: Token, defined_token: Token,
+                 header: str, token_msg: str, defined_msg: str):
+        self.token = token
+        self.defined_token = defined_token
+        self.header = header
+        self.msg = token_msg
+        self.defined_msg = defined_msg
+
+    def __str__(self):
+        index_str = str(self.token.position[0] + 1)
+        defined_index = str(self.defined_token.position[0] + 1)
+        max_pad = max(len(index_str), len(defined_index))
+        border = f"\t{'_' * (len(ErrorSrc.src[self.token.position[0]]) + len(str(self.token.position[0] + 1)) + max_pad)}\n"
+        defined_range = 1 if self.defined_token.end_position is None else self.defined_token.end_position[1] - self.defined_token.position[1] + 1
+        error_range = 1 if self.token.end_position is None else self.token.end_position[1] - self.token.position[1] + 1
+
+        msg = f"{self.header}\n"
+        msg += border
+        msg += f"\t{' ' * max_pad} | \t"
+        msg += Styled.sprintln(
+            self.defined_msg,
+            color=AnsiColor.RED
+        )
+        msg += f"\t{defined_index:{max_pad}} | {ErrorSrc.src[self.defined_token.position[0]]}\n"
+        msg += f"\t{' ' * max_pad} | {' ' * self.defined_token.position[1]}{'^' * (defined_range)}\n"
+        msg += f"\t{' ' * max_pad} | {'_' * (self.defined_token.position[1])}|\n"
+        msg += f"\t{' ' * max_pad} | |\n"
+
+        msg += f"\t{' ' * max_pad} | |\t"
+        msg += Styled.sprintln(
+            self.msg,
+            color=AnsiColor.RED
+        )
+        msg += f"\t{index_str:{max_pad}} | |{ErrorSrc.src[self.token.position[0]]}\n"
+        msg += f"\t{' ' * max_pad} | |{' ' * self.token.position[1]}{'^' * (error_range)}\n"
+        msg += f"\t{' ' * max_pad} | |{'_' * (self.token.position[1])}|\n"
+        msg += border
+
         return msg

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -539,19 +539,19 @@ class TypeChecker:
         method_signature = f"{class_id_str}.{fn_call.id.flat_string()}"
         expected_types = self.class_method_param_types[method_signature]
         self.check_call_args(GlobalType.CLASS_METHOD, method_signature, fn_call.id,
-                             fn_call.args, expected_types, local_defs)
+                             fn_call.args, expected_types, self.class_signatures)
         return return_type.token
 
     def check_call_args(self, global_type: GlobalType, call_str: str, id: Token, call_args: list[Value], expected_types: list[Token], local_defs: dict[str, tuple[Token, Token, GlobalType]]) -> None:
         actual_types = [self.evaluate_value(arg, local_defs) for arg in call_args]
         matches = [self.is_similar_type(actual.flat_string(), expected.flat_string()) for actual, expected in zip(actual_types, expected_types)]
-        if not all(matches):
+        if not all(matches) or len(call_args) != len(expected_types):
             self.errors.append(
                 MismatchedCallArgType(
                     global_type=global_type,
                     call_str=call_str,
                     id=id,
-                    id_definition=local_defs[id.flat_string()][0],
+                    id_definition=local_defs[call_str][0],
                     expected_types=expected_types,
                     args=call_args,
                     actual_types=actual_types,

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -261,7 +261,14 @@ class TypeChecker:
             case PrefixExpression():
                 right = self.evaluate_value(expr.right, local_defs)
                 if not right in self.math_operands():
-                    print(f"ERROR: {expr.right.flat_string()} ({right}) cannot be negative")
+                    self.errors.append(
+                        PrefixOperandError(
+                            expr.op,
+                            expr.right,
+                            local_defs[expr.right.flat_string()][0],
+                            right,
+                        )
+                    )
                 return right
             case InfixExpression():
                 left = self.evaluate_value(expr.left, local_defs)

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -260,13 +260,17 @@ class TypeChecker:
         match expr:
             case PrefixExpression():
                 right = self.evaluate_value(expr.right, local_defs)
-                if not right in self.math_operands():
+                if right not in self.math_operands():
+                    definition = None
+                    if isinstance(expr.right, Token) and isinstance(expr.right.token, UniqueTokenType):
+                        definition = local_defs[expr.right.flat_string()][0]
                     self.errors.append(
-                        PrefixOperandError(
-                            expr.op,
-                            expr.right,
-                            local_defs[expr.right.flat_string()][0],
-                            right,
+                        PrePostFixOperandError(
+                            header=f"Non-Math Prefix Operand: '{expr.right.flat_string()}'",
+                            op=expr.op,
+                            val=expr.right,
+                            val_definition=definition,
+                            val_type=right,
                         )
                     )
                 return right
@@ -306,8 +310,20 @@ class TypeChecker:
                     raise ValueError(f"Unknown operator: {expr.op}")
             case PostfixExpression():
                 left = self.evaluate_value(expr.left, local_defs)
-                if not(left in self.math_operands()):
-                    print(f"ERROR: {expr.left.flat_string()} ({left}) cannot be incremented or decremented")
+                if left not in self.math_operands():
+                        definition = None
+                        if isinstance(expr.left, Token) and isinstance(expr.left.token, UniqueTokenType):
+                            definition = local_defs[expr.left.flat_string()][0]
+                        self.errors.append(
+                            PrePostFixOperandError(
+                                header=f"Non-Math Postfix Operand: '{expr.left.flat_string()}'",
+                                op=expr.op,
+                                val=expr.left,
+                                val_definition=definition,
+                                val_type=left,
+                                postfix=True,
+                            )
+                        )
                 return left
             case _:
                 raise ValueError(f"Unknown expression: {expr}")

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -167,12 +167,11 @@ class TypeChecker:
         if dono_token.exists():
             token = self.extract_id(for_loop.init.id)
             self.errors.append(
-                GenericTwoTokenError(
+                ReassignedConstantError(
                     token = token,
                     defined_token = dono_token,
                     header = f"Constant in for loop initializer: {token.flat_string()}",
                     token_msg = "Tried to use constant in a for loop initializer",
-                    defined_msg = "Declared as constant here",
                 )
             )
 
@@ -201,18 +200,18 @@ class TypeChecker:
         if dono_token.exists():
             token = self.extract_id(assign.id)
             self.errors.append(
-                GenericTwoTokenError(
+                ReassignedConstantError(
                     token = token,
                     defined_token = dono_token,
                     header = f"Reassigning constant: {token.flat_string()}",
                     token_msg = "Tried to reassign here",
-                    defined_msg = "Declared as constant here",
                 )
             )
             return
-        self.check_value(assign.value, expected_type, local_defs)
+        self.check_value(assign.value, expected_type, local_defs, assignment=True)
 
-    def check_value(self, value: Value, expected_type: Token, local_defs: dict[str, tuple[Token, Token, GlobalType]]) -> None:
+    def check_value(self, value: Value, expected_type: Token, local_defs: dict[str, tuple[Token, Token, GlobalType]], assignment: bool = False) -> None:
+        'if `assignment` is true, its an assignment. if false, its a declaration'
         match expected_type.token:
             case TokenType():
                 actual_type = self.evaluate_value(value, local_defs)
@@ -222,6 +221,7 @@ class TypeChecker:
                             expected=expected_type,
                             actual_val=value,
                             actual_type=actual_type,
+                            assignment=assignment,
                         )
                     )
             case UniqueTokenType():
@@ -238,6 +238,7 @@ class TypeChecker:
                                     expected=expected_type,
                                     actual_val=value,
                                     actual_type=actual_type,
+                                    assignment=assignment,
                                 )
                             )
 

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -276,10 +276,20 @@ class TypeChecker:
 
                 if expr.op.token in self.math_operators():
                     if not (left in self.math_operands() and right in self.math_operands()):
-                        tab_newline = '\n\t' # cuz \ is not allowed in f-strings
-                        print(f"ERROR: {expr.left.flat_string()} ({left}) {expr.op} {expr.right.flat_string()} ({right})"
-                            f"{f'{tab_newline}{expr.left.flat_string()} ({left}) is not a math operand' if left not in self.math_operands() else ''}"
-                            f"{f'{tab_newline}{expr.right.flat_string()} ({expr.right.flat_string()} ({right}) is not a math operand' if right not in self.math_operands() else ''}")
+                        left_definition, right_definition = None, None
+                        if isinstance(expr.left, Token) and isinstance(expr.left.token, UniqueTokenType):
+                            left_definition = local_defs[expr.left.flat_string()][0]
+                        if isinstance(expr.right, Token) and isinstance(expr.right.token, UniqueTokenType):
+                            right_definition = local_defs[expr.right.flat_string()][0]
+                        self.errors.append(
+                            InfixOperandError(
+                                expr.op,
+                                (expr.left, left_definition),
+                                (expr.right, right_definition),
+                                left if left not in self.math_operands() else None,
+                                right if right not in self.math_operands() else None,
+                            )
+                        )
                     if left == TokenType.KUN or right == TokenType.KUN:
                         return TokenType.KUN
                     else:

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -187,7 +187,6 @@ class TypeChecker:
                     expected=return_type,
                     return_stmt = ret,
                     actual_type=actual_type,
-                    expected_msg=f"Expected return type: '{return_type}'",
                 )
             )
 

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -218,8 +218,13 @@ class TypeChecker:
             case TokenType():
                 actual_type = self.evaluate_value(value, local_defs)
                 if not self.is_similar_type(actual_type.flat_string(), expected_type.flat_string()):
-                    print(f"ERROR: expected type: {expected_type}\n\t"
-                          f"got: {actual_type} -> {value.flat_string()}")
+                    self.errors.append(
+                        TypeMismatchError(
+                            expected=expected_type,
+                            actual_val=value,
+                            actual_type=actual_type,
+                        )
+                    )
             case UniqueTokenType():
                 match value:
                     case ClassConstructor():
@@ -229,8 +234,13 @@ class TypeChecker:
                     case _:
                         actual_type = self.evaluate_value(value, local_defs)
                         if not self.is_similar_type(actual_type.flat_string(), expected_type.flat_string()):
-                            print(f"ERROR: expected type: {expected_type}\n\t"
-                                  f"got: {actual_type} -> {value.flat_string()}")
+                            self.errors.append(
+                                TypeMismatchError(
+                                    expected=expected_type,
+                                    actual_val=value,
+                                    actual_type=actual_type,
+                                )
+                            )
 
     def evaluate_value(self, value: Value | Token, local_defs: dict[str, tuple[Token, Token|None, GlobalType]]) -> TokenType:
         match value:

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -287,11 +287,12 @@ class TypeChecker:
                             right_definition = local_defs[expr.right.flat_string()][0]
                         self.errors.append(
                             InfixOperandError(
-                                expr.op,
-                                (expr.left, left_definition),
-                                (expr.right, right_definition),
-                                left if left not in self.math_operands() else None,
-                                right if right not in self.math_operands() else None,
+                                header="Non-Math Infix Operand",
+                                op=expr.op,
+                                left=(expr.left, left_definition),
+                                right=(expr.right, right_definition),
+                                left_type=left if left not in self.math_operands() else None,
+                                right_type=right if right not in self.math_operands() else None,
                             )
                         )
                     if left == TokenType.KUN or right == TokenType.KUN:
@@ -300,9 +301,21 @@ class TypeChecker:
                         return TokenType.CHAN
                 elif expr.op.token in self.comparison_operators():
                     if not (left in self.math_operands() and right in self.math_operands()):
-                        print(f"ERROR: {expr.left.flat_string()} ({left}) {expr.op} {expr.right.flat_string()} ({right})\n\t"+
-                              f"{expr.left.flat_string() if left not in self.math_operands() else expr.right.flat_string()}"+
-                              f"({left if left not in self.math_operands() else right}) is not a comparison operand")
+                        left_definition, right_definition = None, None
+                        if isinstance(expr.left, Token) and isinstance(expr.left.token, UniqueTokenType):
+                            left_definition = local_defs[expr.left.flat_string()][0]
+                        if isinstance(expr.right, Token) and isinstance(expr.right.token, UniqueTokenType):
+                            right_definition = local_defs[expr.right.flat_string()][0]
+                        self.errors.append(
+                            InfixOperandError(
+                                header="Non-Comparison Infix Operand: ",
+                                op=expr.op,
+                                left=(expr.left, left_definition),
+                                right=(expr.right, right_definition),
+                                left_type=left if left not in self.math_operands() else None,
+                                right_type=right if right not in self.math_operands() else None,
+                            )
+                        )
                     return TokenType.SAMA
                 elif expr.op.token in self.equality_operators():
                     return TokenType.SAMA

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -184,7 +184,14 @@ class TypeChecker:
     def check_return(self, ret: ReturnStatement, return_type: Token, local_defs: dict[str, tuple[Token, Token|None, GlobalType]]) -> None:
         actual_type = self.evaluate_value(ret.expr, local_defs)
         if not self.is_similar_type(actual_type.flat_string(), return_type.flat_string()):
-            print(f"ERROR: expected return type: {return_type}\n\tgot: {actual_type}")
+            self.errors.append(
+                ReturnTypeMismatchError(
+                    expected=return_type,
+                    return_stmt = ret,
+                    actual_type=actual_type,
+                    expected_msg=f"Expected return type: '{return_type}'",
+                )
+            )
 
     def check_declaration(self, decl: Declaration | ArrayDeclaration, local_defs: dict[str, tuple[Token, Token|None, GlobalType]]) -> None:
         self.check_value(decl.value, decl.dtype, local_defs)

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -13,9 +13,9 @@ class TypeChecker:
         self.program = program
         self.errors = []
 
-        # maps global names to their type's token, whether it's a constant, and GlobalType for error message
-        self.global_defs: dict[str, tuple[Token, bool, GlobalType]] = {}
-        self.class_signatures: dict[str, tuple[Token, bool, GlobalType]] = {}
+        # maps global names to their type's token, the constant token, and GlobalType for error messages
+        self.global_defs: dict[str, tuple[Token, Token|None, GlobalType]] = {}
+        self.class_signatures: dict[str, tuple[Token, Token|None, GlobalType]] = {}
         self.class_method_param_types: dict[str, list[Token]] = {}
         self.function_param_types: dict[str, list[Token]] = {}
         self.class_param_types: dict[str, list[Token]] = {}
@@ -28,33 +28,33 @@ class TypeChecker:
         any duplicates will be appended to error
         '''
         for global_dec in self.program.globals:
-            self.global_defs[global_dec.id.flat_string()] = (global_dec.dtype, global_dec.is_const, GlobalType.IDENTIFIER)
+            self.global_defs[global_dec.id.flat_string()] = (global_dec.dtype, global_dec.dono_token, GlobalType.IDENTIFIER)
         for func in self.program.functions:
-            self.global_defs[func.id.flat_string()] = (func.rtype, False, GlobalType.FUNCTION)
+            self.global_defs[func.id.flat_string()] = (func.rtype, None, GlobalType.FUNCTION)
             self.function_param_types[func.id.flat_string()] = [param.dtype for param in func.params]
         for cwass in self.program.classes:
-            self.global_defs[cwass.id.flat_string()] = (cwass.id, False, GlobalType.CLASS)
+            self.global_defs[cwass.id.flat_string()] = (cwass.id, None, GlobalType.CLASS)
             self.class_param_types[cwass.id.flat_string()] = [param.dtype for param in cwass.params]
             for param in cwass.params:
-                self.class_signatures[f"{cwass.id.flat_string()}.{param.id.flat_string()}"] = (param.dtype, False, GlobalType.CLASS_PROPERTY)
+                self.class_signatures[f"{cwass.id.flat_string()}.{param.id.flat_string()}"] = (param.dtype, None, GlobalType.CLASS_PROPERTY)
             for prop in cwass.properties:
-                self.class_signatures[f"{cwass.id.flat_string()}.{prop.id.flat_string()}"] = (prop.dtype, prop.is_const, GlobalType.CLASS_PROPERTY)
+                self.class_signatures[f"{cwass.id.flat_string()}.{prop.id.flat_string()}"] = (prop.dtype, prop.dono_token, GlobalType.CLASS_PROPERTY)
             for method in cwass.methods:
-                self.class_signatures[f"{cwass.id.flat_string()}.{method.id.flat_string()}"] = (method.rtype, False, GlobalType.CLASS_METHOD)
+                self.class_signatures[f"{cwass.id.flat_string()}.{method.id.flat_string()}"] = (method.rtype, None, GlobalType.CLASS_METHOD)
                 self.class_method_param_types[f"{cwass.id.flat_string()}.{method.id.flat_string()}"] = [param.dtype for param in method.params]
         self.compile_std_types()
 
     def compile_std_types(self):
         self.class_signatures.update(
             {
-                'senpai.len': (Token('chan', TokenType.CHAN), False, GlobalType.CLASS_METHOD),
-                'senpai.reversed': (Token('senpai', TokenType.SENPAI), False, GlobalType.CLASS_METHOD),
-                'senpai.has': (Token('sama', TokenType.SAMA), False, GlobalType.CLASS_METHOD),
-                'senpai.upper': (Token('senpai', TokenType.SENPAI), False, GlobalType.CLASS_METHOD),
-                'senpai.lower': (Token('senpai', TokenType.SENPAI), False, GlobalType.CLASS_METHOD),
+                'senpai.len': (Token('chan', TokenType.CHAN), None, GlobalType.CLASS_METHOD),
+                'senpai.reversed': (Token('senpai', TokenType.SENPAI), None, GlobalType.CLASS_METHOD),
+                'senpai.has': (Token('sama', TokenType.SAMA), None, GlobalType.CLASS_METHOD),
+                'senpai.upper': (Token('senpai', TokenType.SENPAI), None, GlobalType.CLASS_METHOD),
+                'senpai.lower': (Token('senpai', TokenType.SENPAI), None, GlobalType.CLASS_METHOD),
 
-                'array_type.len': (Token('chan', TokenType.CHAN), False, GlobalType.CLASS_METHOD),
-                'array_type.reverse': (Token('san', TokenType.SAN), False, GlobalType.CLASS_METHOD),
+                'array_type.len': (Token('chan', TokenType.CHAN), None, GlobalType.CLASS_METHOD),
+                'array_type.reverse': (Token('san', TokenType.SAN), None, GlobalType.CLASS_METHOD),
             },
         )
         self.class_method_param_types.update(
@@ -76,12 +76,12 @@ class TypeChecker:
         for func in self.program.functions: self.check_function(func, self.global_defs)
         for cwass in self.program.classes: self.check_class(cwass, self.global_defs.copy())
 
-    def check_function(self, func: Function, local_defs: dict[str, tuple[Token, bool, GlobalType]]) -> None:
+    def check_function(self, func: Function, local_defs: dict[str, tuple[Token, Token|None, GlobalType]]) -> None:
         'make sure you pass in a copy of local_defs when calling this'
         self.compile_params(func.params, local_defs)
         self.check_body(func.body, func.rtype, local_defs.copy())
 
-    def check_class(self, cwass: Class, local_defs: dict[str, tuple[Token, bool, GlobalType]]) -> None:
+    def check_class(self, cwass: Class, local_defs: dict[str, tuple[Token, Token|None, GlobalType]]) -> None:
         'make sure you pass in a copy of local_defs when calling this'
         self.compile_params(cwass.params, local_defs)
         for prop in cwass.properties:
@@ -89,12 +89,12 @@ class TypeChecker:
         for method in cwass.methods:
             self.check_function(method, local_defs)
 
-    def compile_params(self, params: list[Parameter], local_defs: dict[str, tuple[Token, bool, GlobalType]]) -> None:
+    def compile_params(self, params: list[Parameter], local_defs: dict[str, tuple[Token, Token|None, GlobalType]]) -> None:
         'make sure you pass in a copy of local_defs when calling this'
         for param in params:
-            local_defs[param.id.flat_string()] = (param.dtype, False, GlobalType.IDENTIFIER)
+            local_defs[param.id.flat_string()] = (param.dtype, None, GlobalType.IDENTIFIER)
 
-    def check_body(self, body: BlockStatement, return_type: Token, local_defs: dict[str, tuple[Token, bool, GlobalType]]) -> None:
+    def check_body(self, body: BlockStatement, return_type: Token, local_defs: dict[str, tuple[Token, Token|None, GlobalType]]) -> None:
         'make sure you pass in a copy of local_defs when calling this'
         for statement in body.statements:
             match statement:
@@ -121,14 +121,14 @@ class TypeChecker:
                 case _:
                     raise ValueError(f"Unknown statement: {statement}")
 
-    def check_print(self, print: Print, local_defs: dict[str, tuple[Token, bool, GlobalType]]) -> None:
+    def check_print(self, print: Print, local_defs: dict[str, tuple[Token, Token|None, GlobalType]]) -> None:
         for val in print.values:
             self.evaluate_value(val, local_defs)
 
-    def check_input(self, input: Input, local_defs: dict[str, tuple[Token, bool, GlobalType]]) -> None:
+    def check_input(self, input: Input, local_defs: dict[str, tuple[Token, Token|None, GlobalType]]) -> None:
         self.evaluate_value(input.expr, local_defs)
 
-    def check_if(self, if_stmt: IfStatement | ElseIfStatement, return_type: Token, local_defs: dict[str, tuple[Token, bool, GlobalType]], else_if=False) -> None:
+    def check_if(self, if_stmt: IfStatement | ElseIfStatement, return_type: Token, local_defs: dict[str, tuple[Token, Token|None, GlobalType]], else_if=False) -> None:
         self.evaluate_value(if_stmt.condition, local_defs)
         self.check_body(if_stmt.then, return_type, local_defs.copy())
         if else_if: return
@@ -138,56 +138,55 @@ class TypeChecker:
         if if_stmt.else_block:
             self.check_body(if_stmt.else_block, return_type, local_defs.copy())
 
-    def check_while_loop(self, while_loop: WhileLoop, return_type: Token, local_defs: dict[str, tuple[Token, bool, GlobalType]]) -> None:
+    def check_while_loop(self, while_loop: WhileLoop, return_type: Token, local_defs: dict[str, tuple[Token, Token|None, GlobalType]]) -> None:
         self.evaluate_value(while_loop.condition, local_defs)
         self.check_body(while_loop.body, return_type, local_defs.copy())
 
-    def check_for_loop(self, for_loop: ForLoop, return_type: Token, local_defs: dict[str, tuple[Token, bool, GlobalType]]) -> None:
+    def check_for_loop(self, for_loop: ForLoop, return_type: Token, local_defs: dict[str, tuple[Token, Token|None, GlobalType]]) -> None:
         'pass in a copy of local defs when calling this'
         match for_loop.init:
             case Declaration() | ArrayDeclaration():
                 self.check_declaration(for_loop.init, local_defs)
-                _, is_const, _ = local_defs[for_loop.init.id.flat_string()]
+                _, dono_token, _ = local_defs[for_loop.init.id.flat_string()]
             case Assignment():
                 self.check_assignment(for_loop.init, local_defs)
-                _, is_const, _ = local_defs[self.extract_id(for_loop.init.id)]
+                _, dono_token, _ = local_defs[self.extract_id(for_loop.init.id).flat_string()]
             case Token():
                 self.evaluate_token(for_loop.init, local_defs)
                 match for_loop.init.token:
                     case Token():
-                        is_const = False
+                        dono_token = False
                     case UniqueTokenType():
-                        _, is_const, _ = local_defs[for_loop.init.flat_string()]
+                        _, dono_token, _ = local_defs[for_loop.init.flat_string()]
                     case _:
                         raise ValueError(f"Unknown token: {for_loop.init}")
             case IdentifierProds():
                 self.evaluate_ident_prods(for_loop.init, local_defs)
-                _, is_const = self.extract_last_id(for_loop.init, local_defs)
-
-        if is_const:
             print(f"ERROR: can't modify constant '{for_loop.init.id.flat_string()}' in for loop")
+                _, dono_token = self.extract_last_id(for_loop.init, local_defs)
+        if dono_token:
 
         self.evaluate_value(for_loop.condition, local_defs)
         self.evaluate_value(for_loop.update, local_defs)
         self.check_body(for_loop.body, return_type, local_defs.copy())
 
-    def check_return(self, ret: ReturnStatement, return_type: Token, local_defs: dict[str, tuple[Token, bool, GlobalType]]) -> None:
+    def check_return(self, ret: ReturnStatement, return_type: Token, local_defs: dict[str, tuple[Token, Token|None, GlobalType]]) -> None:
         actual_type = self.evaluate_value(ret.expr, local_defs)
         if not self.is_similar_type(actual_type.flat_string(), return_type.flat_string()):
             print(f"ERROR: expected return type: {return_type}\n\tgot: {actual_type}")
 
-    def check_declaration(self, decl: Declaration | ArrayDeclaration, local_defs: dict[str, tuple[Token, bool, GlobalType]]) -> None:
+    def check_declaration(self, decl: Declaration | ArrayDeclaration, local_defs: dict[str, tuple[Token, Token|None, GlobalType]]) -> None:
         self.check_value(decl.value, decl.dtype, local_defs)
-        local_defs[decl.id.flat_string()] = (decl.dtype, decl.is_const, GlobalType.IDENTIFIER)
+        local_defs[decl.id.flat_string()] = (decl.dtype, decl.dono_token, GlobalType.IDENTIFIER)
 
-    def check_assignment(self, assign: Assignment, local_defs: dict[str, tuple[Token, bool, GlobalType]]) -> None:
-        expected_type, is_const = self.extract_last_id(assign.id, local_defs)
-        if is_const:
             print(f"ERROR: cannot assign to constant: {assign.id.flat_string()}")
+    def check_assignment(self, assign: Assignment, local_defs: dict[str, tuple[Token, Token|None, GlobalType]]) -> None:
+        expected_type, dono_token = self.extract_last_id(assign.id, local_defs)
+        if dono_token:
             return
         self.check_value(assign.value, expected_type, local_defs)
 
-    def check_value(self, value: Value, expected_type: Token, local_defs: dict[str, tuple[Token, bool, GlobalType]]) -> None:
+    def check_value(self, value: Value, expected_type: Token, local_defs: dict[str, tuple[Token, Token|None, GlobalType]]) -> None:
         match expected_type.token:
             case TokenType():
                 actual_type = self.evaluate_value(value, local_defs)
@@ -206,7 +205,7 @@ class TypeChecker:
                             print(f"ERROR: expected type: {expected_type}\n\t"
                                   f"got: {actual_type} -> {value.flat_string()}")
 
-    def evaluate_value(self, value: Value | Token, local_defs: dict[str, tuple[Token, bool, GlobalType]]) -> TokenType:
+    def evaluate_value(self, value: Value | Token, local_defs: dict[str, tuple[Token, Token|None, GlobalType]]) -> TokenType:
         match value:
             case Token():
                 return self.evaluate_token(value, local_defs)
@@ -220,7 +219,7 @@ class TypeChecker:
                 if value.flat_string() != None: raise ValueError(f"Unknown value: {value.flat_string()}")
                 return TokenType.SAN
 
-    def evaluate_expression(self, expr: Expression, local_defs: dict[str, tuple[Token, bool, GlobalType]]) -> TokenType:
+    def evaluate_expression(self, expr: Expression, local_defs: dict[str, tuple[Token, Token|None, GlobalType]]) -> TokenType:
         match expr:
             case PrefixExpression():
                 right = self.evaluate_value(expr.right, local_defs)
@@ -259,7 +258,7 @@ class TypeChecker:
             case _:
                 raise ValueError(f"Unknown expression: {expr}")
 
-    def evaluate_ident_prods(self, ident_prod: IdentifierProds, local_defs: dict[str, tuple[Token, bool, GlobalType]]) -> TokenType:
+    def evaluate_ident_prods(self, ident_prod: IdentifierProds, local_defs: dict[str, tuple[Token, Token|None, GlobalType]]) -> TokenType:
         match ident_prod:
             case IndexedIdentifier():
                 for idx in ident_prod.index:
@@ -286,9 +285,9 @@ class TypeChecker:
             case _:
                 raise ValueError(f"Unknown identifier production: {ident_prod}")
 
-    def check_and_evaluate_class_accessor(self, accessor: ClassAccessor, local_defs: dict[str, tuple[Token, bool, GlobalType]]) -> TokenType:
+    def check_and_evaluate_class_accessor(self, accessor: ClassAccessor, local_defs: dict[str, tuple[Token, Token|None, GlobalType]]) -> TokenType:
         # check that the accessor is of type class
-        id = self.extract_id(accessor)
+        id = self.extract_id(accessor).flat_string()
         match accessor.id:
             case Token() | FnCall() | ClassAccessor():
                 res = local_defs.get(id)
@@ -358,7 +357,7 @@ class TypeChecker:
             case _:
                 raise ValueError(f"Unknown class accessor: {accessor}")
 
-    def evaluate_iterable(self, collection: Iterable, local_defs: dict[str, tuple[Token, bool, GlobalType]]) -> TokenType:
+    def evaluate_iterable(self, collection: Iterable, local_defs: dict[str, tuple[Token, Token|None, GlobalType]]) -> TokenType:
         match collection:
             case ArrayLiteral():
                 flat_arr, units_type = self.expect_homogenous(collection, local_defs)
@@ -383,7 +382,7 @@ class TypeChecker:
             case _:
                 raise ValueError(f"Unknown collection: {collection}")
 
-    def evaluate_method_call(self, class_id: Token, fn_call: FnCall, local_defs: dict[str, tuple[Token, bool, GlobalType]]) -> TokenType:
+    def evaluate_method_call(self, class_id: Token, fn_call: FnCall, local_defs: dict[str, tuple[Token, Token|None, GlobalType]]) -> TokenType:
         class_id_str = class_id.flat_string() if not class_id.token.is_arr_type() else 'array_type'
         if (res := self.class_signatures.get(f"{class_id_str}.{fn_call.id.flat_string()}")) is None:
             print(f"ERROR: '{fn_call.id.flat_string()}' is not a method of class '{class_id.flat_string()}'")
@@ -404,7 +403,7 @@ class TypeChecker:
 
         return return_type.token
 
-    def evaluate_fn_call(self, fn_call: FnCall, local_defs: dict[str, tuple[Token, bool, GlobalType]]) -> TokenType:
+    def evaluate_fn_call(self, fn_call: FnCall, local_defs: dict[str, tuple[Token, Token|None, GlobalType]]) -> TokenType:
         expected_types = self.function_param_types[fn_call.id.flat_string()]
         if len(fn_call.args) != len(expected_types):
             print(f"ERROR: wrong number of args for fn '{fn_call.id.flat_string()}': expected {len(expected_types)}, got {len(fn_call.args)}")
@@ -414,7 +413,7 @@ class TypeChecker:
                 print(f"ERROR: wrong param type for fn '{fn_call.id.flat_string()}'\n\texpected: {arg_type.flat_string()}\n\tgot: {actual_type.flat_string()} -> {arg.flat_string()}")
         return local_defs[fn_call.id.flat_string()][0].token
 
-    def check_class_constructor(self, class_constructor: ClassConstructor, local_defs: dict[str, tuple[Token, bool, GlobalType]]) -> None:
+    def check_class_constructor(self, class_constructor: ClassConstructor, local_defs: dict[str, tuple[Token, Token|None, GlobalType]]) -> None:
         expected_types = self.class_param_types[class_constructor.id.flat_string()]
         if len(expected_types) != len(class_constructor.args):
             print(f"ERROR: wrong number of args for class {class_constructor.id.flat_string()}: expected {len(expected_types)}, got {len(class_constructor.args)}")
@@ -423,7 +422,7 @@ class TypeChecker:
             if not self.is_similar_type(actual_type.flat_string(), arg_type.flat_string()):
                 print(f"ERROR: wrong param type for class {class_constructor.id.flat_string()}\n\texpected: {arg_type.flat_string()}\n\tgot: {actual_type.flat_string()} -> {arg.flat_string()}")
 
-    def evaluate_token(self, token: Token, local_defs: dict[str, tuple[Token, bool, GlobalType]]) -> TokenType:
+    def evaluate_token(self, token: Token, local_defs: dict[str, tuple[Token, Token|None, GlobalType]]) -> TokenType:
         match token.token:
             case TokenType.STRING_LITERAL: return TokenType.SENPAI
             case TokenType.INT_LITERAL: return TokenType.CHAN
@@ -447,7 +446,7 @@ class TypeChecker:
                 TokenType.AND_OPERATOR, TokenType.OR_OPERATOR]
     
     ## HELPER METHODS FOR EVALUATING ARRAYS
-    def expect_homogenous(self, arr: ArrayLiteral, local_defs: dict[str, tuple[Token, bool, GlobalType]]) -> tuple[list[Value], TokenType]:
+    def expect_homogenous(self, arr: ArrayLiteral, local_defs: dict[str, tuple[Token, Token|None, GlobalType]]) -> tuple[list[Value], TokenType]:
         flat_arr = self.flatten_array(arr.elements)
         types: set[TokenType] = set()
         for val in flat_arr:
@@ -498,19 +497,19 @@ class TypeChecker:
             case _: return False
 
     ## HELPER METHODS TO EXTRACT TYPES
-    def extract_id(self, accessor: Token | FnCall | IndexedIdentifier | ClassAccessor) -> str:
+    def extract_id(self, accessor: Token | FnCall | IndexedIdentifier | ClassAccessor) -> Token:
         'gets the very first id of a class accessor'
         match accessor:
             case Token():
-                return accessor.flat_string()
+                return accessor
             case FnCall():
-                return accessor.id.flat_string()
+                return accessor.id
             case IndexedIdentifier():
                 match accessor.id:
                     case Token():
-                        return accessor.id.flat_string()
+                        return accessor.id
                     case FnCall():
-                        return accessor.id.id.flat_string()
+                        return accessor.id.id
                     case _:
                         raise ValueError(f"Unknown class accessor: {accessor}")
             case ClassAccessor():
@@ -518,7 +517,7 @@ class TypeChecker:
             case _:
                 raise ValueError(f"Unknown class accessor: {accessor}")
 
-    def extract_last_id(self, val: Token | FnCall | IndexedIdentifier | ClassAccessor, local_defs: dict[str, tuple[Token, bool, GlobalType]]) -> tuple[Token, bool]:
+    def extract_last_id(self, val: Token | FnCall | IndexedIdentifier | ClassAccessor, local_defs: dict[str, tuple[Token, Token|None, GlobalType]]) -> tuple[Token, Token|None]:
         match val:
             case Token():
                 return local_defs[val.flat_string()][0:2]

--- a/src/lexer/token.py
+++ b/src/lexer/token.py
@@ -72,6 +72,10 @@ class TokenType(Enum):
                 return TokenType.SENPAI
             case _:
                 return self
+    def is_unique_type(self):
+        return False
+    def exists(self) -> bool:
+        return self != TokenType.EOF
 
     # GENERAL KEYWORDS
     MAINUWU = ("mainuwu", "mainuwu")
@@ -230,6 +234,10 @@ class UniqueTokenType:
         return self
     def is_arr_type(self):
         return self.token.endswith("[]")
+    def is_unique_type(self):
+        return True
+    def exists(self) -> bool:
+        return True
 
 
 class Token:
@@ -292,6 +300,11 @@ class Token:
             case UniqueTokenType():
                 ret._token = ret._token.to_unit_type()
         return ret
+
+    def is_unique_type(self):
+        return self.token.is_unique_type()
+    def exists(self) -> bool:
+        return self.token.exists()
 
     @property
     def lexeme(self) -> str:

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -306,6 +306,7 @@ class Parser:
                 self.advance(2)
                 return None
             d.is_const = True
+            d.dono_token = self.curr_tok
 
         # uninitialized
         if not self.expect_peek(TokenType.ASSIGNMENT_OPERATOR):

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -260,6 +260,7 @@ class Declaration(Statement):
         self.dtype: Token = Token() 
         self.value: Value = Value()
         self.is_const: bool = False
+        self.dono_token: Token = Token()
 
     def header(self):
         return f"declare {'constant' if self.is_const else 'variable'}: {self.id.string()}"
@@ -281,6 +282,7 @@ class ArrayDeclaration(Statement):
         self.dtype: Token = Token()
         self.value: Value = Value()
         self.is_const: bool = False
+        self.dono_token: Token = Token()
 
     def header(self):
         return f"declare{' constant' if self.is_const else ''} array: {self.id.string()}"

--- a/src/style/style.py
+++ b/src/style/style.py
@@ -9,6 +9,18 @@ class AnsiColor(Enum):
     WHITE = '\033[97m'
     RESET = '\033[0m'
 
+    @staticmethod
+    def colors_iter():
+        '''
+        Yields colors in order. This loops back to first color after last color.
+        This is intended to be used with next(), not in a loop.
+        '''
+        colors = [AnsiColor.RED, AnsiColor.GREEN, AnsiColor.YELLOW, AnsiColor.BLUE, AnsiColor.MAGENTA, AnsiColor.CYAN]
+        while True:
+            for color in colors:
+                yield color
+
+
 class Styled:
     @staticmethod
     def print(*msgs, color: AnsiColor = AnsiColor.RESET, sep = ' ', end = '\n'):


### PR DESCRIPTION
# full type checking!
- all builtin unit types (`chan` `kun` `senpai` `sama` `san`) can be converted to sama so:
```
a-sama = "hello"~
```
is valid
- all types can accept `san` values so:
```
a-kun[] = nuww~
```
is valid
- chan and kun can accept each other (also sama) so
```
a-chan = fax~
b-kun = cap~
c-chan = 1.1~
d-kun = 1~
```
are all valid
- every type not mentioned (aka array types and user defined types) need exact matches
  - _or be assigned `nuww` or a `san` value since all types can accept `san` values_
---

enjoy the slideshow
### reassigning constant
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/66142c45-3107-435f-a405-fa3db4e45a13)
### constant in for loop init
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/5aab26ca-079c-45ee-9bbb-19d67d0c9bd6)
### return type mismatch
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/9225da36-f1e4-4b0b-8d64-00c9e9ae2412)
### type mismatch 
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/ae307bb0-78af-482a-9076-a91aff2f8a2f)
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/eafa9984-1287-4d67-9c33-61e019e796e1)
### non math postfix operand
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/0ae0c386-376b-4292-9345-73891fe84a0e)
### non math prefix operand
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/f656980b-6580-4c83-a16a-66d8c7315b7e)
### non math infix operand
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/e8635aae-b0d7-48b7-9c76-8b02c9c6c209)
### non iterable indexing
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/d6883420-d1c7-4274-8e74-ef88dbad60d9)
### non class access
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/86c48c2c-c655-4d39-b066-47b5ab5834f5)
### undefined class property
_methods used as property gets additional context as to where it was defined and that it should be used as a method_
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/bc8a026d-806c-424a-98e9-c47082e1a9ff)
### undefined class method
_property used as method gets additional context as to where it was defined and that it should be used as a property_
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/8c0bd57f-d0c9-46c2-bb6a-9c88b541c085)
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/83ce8af3-f7fd-43f8-9d2a-057f207bbcb4)
### call args type mismatch (for fn calls, method calls, and class constructors)
_too much args, too less args, and general mismatch error_
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/f31e11dd-9167-4d96-9c30-245c9178d815)
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/3f54f5de-857a-458f-8aae-dd6b809fe1af)
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/05460ca2-41d4-4eb3-9afa-4353c7b17362)
### heterogeneous arrays
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/5297af68-0226-4c12-a685-020135114642)
