### PR TITLE
fix: re-add builtin type methods in type checking

### DIFF
--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -381,7 +381,7 @@ class TypeChecker:
         match accessor.id:
             case Token() | FnCall() | ClassAccessor():
                 class_type, _, _ = local_defs[id]
-                if not class_type.is_unique_type():
+                if not class_type.is_unique_type() and not self.is_accessible(class_type.token):
                     self.errors.append(
                         NonClassAccessError(
                             id=self.extract_id(accessor),


### PR DESCRIPTION
closes #165 

# methods of builtin `senpai` and all array types can be accessed and checked in type checking
_produced no errors_
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/c7b98724-90cc-47d2-a518-a902ee304b79)


![image](https://github.com/Gidsss/UwUIDE/assets/146176671/3928bc50-6d16-4c68-aafe-ee226f4df62c)
