### PR TITLE
fix: method error message now doesn't show where it is defined

### DIFF
--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -551,7 +551,7 @@ class TypeChecker:
                     global_type=global_type,
                     call_str=call_str,
                     id=id,
-                    id_definition=local_defs[call_str][0],
+                    id_definition=local_defs[call_str][0] if call_str not in self.class_signatures.keys() else None,
                     expected_types=expected_types,
                     args=call_args,
                     actual_types=actual_types,


### PR DESCRIPTION
# before
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/249b937e-7862-481b-abe7-a81f36224206)

# after
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/e7030fde-f162-4902-9e01-41d3988e8341)
