### PR TITLE
Feat/uninitialized var const usage error

### DIFF
--- a/src/analyzer/analyzer.py
+++ b/src/analyzer/analyzer.py
@@ -87,10 +87,9 @@ class MemberAnalyzer:
             else:
                 local_defs[f"{cwass.id.flat_string()}.{method.id.string()}"] = (method.id, GlobalType.CLASS_METHOD)
 
-    def analyze_param(self, param: Parameter, local_defs: dict[str, tuple[Token, GlobalType]],
+    def analyze_param(self, param: Declaration, local_defs: dict[str, tuple[Token, GlobalType]],
                       *,
                       cwass=False) -> None:
-        assert isinstance(param.id, Token)
         if param.id.string() in local_defs:
             self.errors.append(DuplicateDefinitionError(
                 *local_defs[param.id.string()],
@@ -116,7 +115,7 @@ class MemberAnalyzer:
                     self.analyze_print(stmt, local_defs)
                 case Input():
                     self.analyze_input(stmt, local_defs)
-                case Declaration() | ArrayDeclaration():
+                case Declaration():
                     self.analyze_declaration(stmt, local_defs, cwass=cwass, in_body=True)
                 case Assignment():
                     self.analyze_assignment(stmt, local_defs)
@@ -151,7 +150,7 @@ class MemberAnalyzer:
         if if_stmt.else_block:
             self.analyze_body(if_stmt.else_block, local_defs.copy())
 
-    def analyze_declaration(self, decl: Declaration | ArrayDeclaration, local_defs: dict[str, tuple[Token, GlobalType]],
+    def analyze_declaration(self, decl: Declaration, local_defs: dict[str, tuple[Token, GlobalType]],
                             *,
                             cwass=False, in_body=False) -> None:
         self.expect_unique_token(decl.id,
@@ -188,7 +187,7 @@ class MemberAnalyzer:
         match for_loop.init:
             case Assignment():
                 self.analyze_assignment(for_loop.init, local_defs)
-            case Declaration() | ArrayDeclaration():
+            case Declaration():
                 self.analyze_declaration(for_loop.init, local_defs)
             case Token():
                 self.expect_defined_token(for_loop.init, GlobalType.IDENTIFIER, local_defs)

--- a/src/analyzer/error_handler.py
+++ b/src/analyzer/error_handler.py
@@ -345,7 +345,7 @@ class InfixOperandError:
             lhs_index = str(self.left_definition.position[0] + 1)
             msg += f"\n\t{' ' * max_pad} | \t"
             msg += Styled.sprintln(
-                f"Left hand side defined here",
+                f"Left value defined here",
                 color=AnsiColor.GREEN,
             )
             msg += f"\t{lhs_index:{max_pad}} | {ErrorSrc.src[self.left_definition.position[0]]}\n"
@@ -355,7 +355,7 @@ class InfixOperandError:
         if self.left_type:
             msg += f"\n\t{' ' * max_pad} | "f"{'|' if self.left_definition else ''}""\t"
             msg += Styled.sprintln(
-                f"Value below evaluates to type: '{self.left_type.flat_string()}'",
+                f"Left value evaluates to type: '{self.left_type.flat_string()}'",
                 color=AnsiColor.RED
             )
             msg += f"\t{op_str:{max_pad}} | " f"{'|' if self.left_definition else ''}" f"  {self.left.flat_string()}{self.op.flat_string()}{self.right.flat_string()}\n"
@@ -370,7 +370,7 @@ class InfixOperandError:
             rhs_index = str(self.right_definition.position[0] + 1)
             msg += f"\n\t{' ' * max_pad} | \t"
             msg += Styled.sprintln(
-                f"Right hand side defined here",
+                f"Right value defined here",
                 color=AnsiColor.GREEN,
             )
             msg += f"\t{rhs_index:{max_pad}} | {ErrorSrc.src[self.right_definition.position[0]]}\n"
@@ -380,7 +380,7 @@ class InfixOperandError:
         if self.right_type:
             msg += f"\n\t{' ' * max_pad} | " f"{'|' if self.right_definition else ''}" "\t"
             msg += Styled.sprintln(
-                f"Value below evaluates to type: '{self.right_type.flat_string()}'",
+                f"Right value evaluates to type: '{self.right_type.flat_string()}'",
                 color=AnsiColor.RED
             )
             msg += f"\t{op_str:{max_pad}} | " f"{'|' if self.right_definition else ''}" f"  {self.left.flat_string()}{self.op.flat_string()}{self.right.flat_string()}\n"
@@ -650,7 +650,7 @@ class NoReturnStatement:
         self.cwass = cwass
 
     def __str__(self):
-        last_stmt = self.final_statement(self.func.body) + 1
+        last_stmt = final_statement(self.func.body) + 1
         rtype_index_str = str(self.func.rtype.position[0] + 1)
         max_pad = max(len(rtype_index_str), 4)
         max_len = max(len(ErrorSrc.src[self.func.rtype.position[0]]), len(ErrorSrc.src[last_stmt-1]))
@@ -676,78 +676,76 @@ class NoReturnStatement:
         msg += f"\t{' ' * max_pad} |\t"
         msg += Styled.sprintln(
             f"Consider adding a return statement somewhere",
-            color=AnsiColor.GREEN
+            color=AnsiColor.CYAN
         )
         msg += f"\t{' ' * max_pad} |\t"
         msg += Styled.sprintln(
             f"like after the statement in line {last_stmt}",
-            color=AnsiColor.GREEN
+            color=AnsiColor.CYAN
         )
-        default_return = self.default_rtype(self.func.rtype.token)
+        default_return = default_rtype(self.func.rtype.token)
         msg += f"\t{last_stmt:<{max_pad}} |\t\t{ErrorSrc.src[last_stmt-1].strip()}\n"
         msg += f"\t{f'...n':<{max_pad}} |\t\twetuwn({default_return})~\n"
         msg += f"\t{' ' * max_pad} |\t\t^^^^^^^^^{'^' * len(default_return)}\n"
         msg += border
         return msg
 
-
-    def extract_id(self, accessor: Token | FnCall | IndexedIdentifier | ClassAccessor) -> Token:
-        'gets the very first id of a class accessor'
-        match accessor:
-            case Token():
-                return accessor
-            case FnCall():
-                return accessor.id
-            case IndexedIdentifier():
-                match accessor.id:
-                    case Token():
-                        return accessor.id
-                    case FnCall():
-                        return accessor.id.id
-                    case _:
-                        raise ValueError(f"Unknown class accessor: {accessor}")
-            case ClassAccessor():
-                return self.extract_id(accessor.id)
-            case _:
-                raise ValueError(f"Unknown class accessor: {accessor}")
-
-    def final_statement(self, body: BlockStatement) -> int:
-        stmt: Statement = body.statements[-1]
-        match stmt:
-            case Print():
-                return stmt.print.position[0]
-            case Declaration() | ArrayDeclaration():
-                return stmt.id.position[0]
-            case Assignment():
-                return self.extract_id(stmt.id).position[0]
-            case IfStatement():
-                if stmt.else_block.statements:
-                    return self.final_statement(stmt.else_block)
-                elif stmt.else_if:
-                    return self.final_statement(stmt.else_if[-1].then)
-                else:
-                    return self.final_statement(stmt.then)
-            case WhileLoop() | ForLoop():
-                return self.final_statement(stmt.body)
-            case _:
-                raise ValueError(f"Unknown statement: {stmt}")
-
-    def default_rtype(self, token: TokenType) -> str:
-        match token:
-            case UniqueTokenType():
-                if token.is_arr_type():
-                    return '{}'
-                else:
-                    return token.token + '()'
-            case TokenType.CHAN_ARR | TokenType.KUN_ARR | TokenType.SAMA_ARR | TokenType.SAN_ARR | TokenType.SENPAI_ARR:
+### HELPER FUNCTIONS FOR SUGGESTIONS
+def extract_id(accessor: Token | FnCall | IndexedIdentifier | ClassAccessor) -> Token:
+    'gets the very first id of a class accessor'
+    match accessor:
+        case Token():
+            return accessor
+        case FnCall():
+            return accessor.id
+        case IndexedIdentifier():
+            match accessor.id:
+                case Token():
+                    return accessor.id
+                case FnCall():
+                    return accessor.id.id
+                case _:
+                    raise ValueError(f"Unknown class accessor: {accessor}")
+        case ClassAccessor():
+            return extract_id(accessor.id)
+        case _:
+            raise ValueError(f"Unknown class accessor: {accessor}")
+def final_statement(body: BlockStatement) -> int:
+    stmt: Statement = body.statements[-1]
+    match stmt:
+        case Print():
+            return stmt.print.position[0]
+        case Declaration():
+            return stmt.id.position[0]
+        case Assignment():
+            return extract_id(stmt.id).position[0]
+        case IfStatement():
+            if stmt.else_block.statements:
+                return final_statement(stmt.else_block)
+            elif stmt.else_if:
+                return final_statement(stmt.else_if[-1].then)
+            else:
+                return final_statement(stmt.then)
+        case WhileLoop() | ForLoop():
+            return final_statement(stmt.body)
+        case _:
+            raise ValueError(f"Unknown statement: {stmt}")
+def default_rtype(token: TokenType) -> str:
+    match token:
+        case UniqueTokenType():
+            if token.is_arr_type():
                 return '{}'
-            case TokenType.CHAN:
-                return '0'
-            case TokenType.KUN:
-                return '0.0'
-            case TokenType.SAMA:
-                return 'cap'
-            case TokenType.SENPAI:
-                return '""'
-            case _:
-                raise ValueError(f"Unknown token: {token}")
+            else:
+                return token.token + '()'
+        case TokenType.CHAN_ARR | TokenType.KUN_ARR | TokenType.SAMA_ARR | TokenType.SAN_ARR | TokenType.SENPAI_ARR:
+            return '{}'
+        case TokenType.CHAN:
+            return '0'
+        case TokenType.KUN:
+            return '0.0'
+        case TokenType.SAMA:
+            return 'cap'
+        case TokenType.SENPAI:
+            return '""'
+        case _:
+            raise ValueError(f"Unknown token: {token}")

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -662,12 +662,12 @@ class TypeChecker:
                 res.append(item)
         return res
 
-    def is_similar_type(self, actual_type: str, expected_type: str) -> bool:
+    def is_similar_type(self, actual_type: str, expected_type: str, is_call: bool = False) -> bool:
         'determines if two types are similar'
+        # nuww is an ok val for any type if and only if its not for a call
+        condition_2 = (actual_type == 'san') if not is_call else False
         if (actual_type == expected_type 
-            # nuww is an ok val for any type
-            or actual_type == "san"
-            ): return True
+            or condition_2): return True
 
         assert actual_type != expected_type
         match expected_type:

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -608,7 +608,11 @@ class TypeChecker:
             case TokenType.FLOAT_LITERAL: return TokenType.KUN
             case TokenType.FAX | TokenType.CAP: return TokenType.SAMA
             case TokenType.NUWW: return TokenType.SAN
-            case UniqueTokenType(): return local_defs[token.flat_string()][0].dtype.token
+            case UniqueTokenType():
+                decl = local_defs[token.flat_string()][0]
+                if not decl.initialized:
+                    return TokenType.SAN
+                return decl.dtype.token
             case _: raise ValueError(f"Unknown token: {token}")
 
     ## HELPER METHODS FOR OPERATORS AND OPERANDS

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -264,8 +264,6 @@ class TypeChecker:
                     case ClassConstructor():
                         actual_type = UniqueTokenType() # placeholder, will not be used in this case
                         self.check_class_constructor(value, local_defs)
-                        for arg in value.args:
-                            self.evaluate_value(arg, local_defs)
                     case _:
                         actual_type = self.evaluate_value(value, local_defs)
                         if not self.is_similar_type(actual_type.flat_string(), expected_type.flat_string()):

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -275,18 +275,22 @@ class TypeChecker:
                                     assignment=assignment,
                                 )
                             )
-        # uninitialize identifiers if any errors occured in evaluating value
+        # (DECLARATION & ASSIGNMENT) uninitialize identifiers if any errors occured in evaluating value
         if self.expr_err_count > 0 and expected_type != TokenType.SAN:
             decl_new = deepcopy(decl)
             decl_new.initialized = False
             decl_new.value = Value()
             local_defs[decl_new.id.flat_string()] = (decl_new, decl_new.dtype, GlobalType.IDENTIFIER)
 
-        # initialize uninitialized identifiers
+        # (ASSIGNMENT) initialize uninitialized identifiers
         elif not decl.initialized and actual_type != TokenType.SAN:
             decl_new = deepcopy(decl)
             decl_new.initialized = True
             local_defs[decl_new.id.flat_string()] = (decl_new, decl_new.dtype, GlobalType.IDENTIFIER)
+
+        # (DECLARATION & ASSIGNMENT) initialize identifiers with assigned values
+        else:
+            local_defs[decl.id.flat_string()] = (decl, decl.dtype, GlobalType.IDENTIFIER)
 
         if assignment:
             assign.dtype = actual_type

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -433,7 +433,7 @@ class TypeChecker:
         id = self.extract_id(accessor).flat_string()
         match accessor.id:
             case Token() | FnCall() | ClassAccessor():
-                class_type = local_defs[id][0].id
+                class_type = local_defs[id][0].dtype
                 if not class_type.is_unique_type() and not self.is_accessible(class_type.token):
                     self.errors.append(
                         NonClassAccessError(
@@ -443,14 +443,14 @@ class TypeChecker:
                         )
                     )
             case IndexedIdentifier():
-                class_type = local_defs[id][0].id
+                class_type = local_defs[id][0].dtype
                 if not self.is_accessible(class_type.token):
                     token = self.extract_id(accessor.id)
                     type_definition = local_defs[token.flat_string()][0]
                     self.errors.append(
                         NonIterableIndexingError(
                             token=token,
-                            type_definition=type_definition.id,
+                            type_definition=type_definition.dtype,
                             token_type=class_type.token,
                             usage=accessor.id.flat_string(),
                         )

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -241,9 +241,10 @@ class TypeChecker:
                     class_signature=signature,
                 )
             )
-        self.check_value(assign.value, decl.dtype, local_defs, assignment=True, decl=decl)
+        self.check_value(assign.value, decl.dtype, local_defs, assignment=True, decl=decl, assign=assign)
 
-    def check_value(self, value: Value, expected_type: Token, local_defs: dict[str, tuple[Declaration, Token, GlobalType]], assignment: bool = False, decl: Declaration = Declaration()) -> None:
+    def check_value(self, value: Value, expected_type: Token, local_defs: dict[str, tuple[Declaration, Token, GlobalType]],
+                    assignment: bool = False, decl: Declaration = Declaration(), assign: Assignment = Assignment()) -> None:
         'if `assignment` is true, its an assignment. if false, its a declaration'
         self.expr_err_count = 0
 
@@ -288,6 +289,8 @@ class TypeChecker:
                 decl_new = deepcopy(decl)
                 decl_new.initialized = True
                 local_defs[decl_new.id.flat_string()] = (decl_new, decl_new.dtype, GlobalType.IDENTIFIER)
+
+            assign.dtype = actual_type
         self.expr_err_count = 0
 
     def evaluate_value(self, value: Value | Token, local_defs: dict[str, tuple[Declaration, Token, GlobalType]]) -> TokenType:

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -617,7 +617,7 @@ class TypeChecker:
 
     ## HELPER METHODS FOR OPERATORS AND OPERANDS
     def math_operands(self) -> list[TokenType]:
-        return [TokenType.CHAN, TokenType.KUN, TokenType.SAMA, TokenType.SAN]
+        return [TokenType.CHAN, TokenType.KUN, TokenType.SAMA]
     def math_operators(self) -> list[TokenType]:
         return [TokenType.ADDITION_SIGN, TokenType.DASH, TokenType.MULTIPLICATION_SIGN,
                 TokenType.DIVISION_SIGN, TokenType.MODULO_SIGN]

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -576,15 +576,29 @@ class TypeChecker:
         return return_type.id.token
 
     def check_call_args(self, global_type: GlobalType, call_str: str, id: Token, call_args: list[Value], expected_types: list[Token], local_defs: dict[str, tuple[Declaration, Token, GlobalType]]) -> None:
-        actual_types = [self.evaluate_value(arg, local_defs) for arg in call_args]
-        matches = [self.is_similar_type(actual.flat_string(), expected.flat_string()) for actual, expected in zip(actual_types, expected_types)]
+        actual_types = []
+        matches = []
+        for arg, expected in zip(call_args, expected_types):
+            self.expr_err_count = 0
+            match arg:
+                case Token():
+                    actual_def = local_defs[arg.flat_string()][0]
+                    actual = actual_def.dtype
+                    if not actual_def.initialized: actual = TokenType.SAN
+                case _:
+                    actual = self.evaluate_value(arg, local_defs)
+                    if self.expr_err_count > 0: actual = TokenType.SAN
+            actual_types.append(actual)
+            matches.append(self.is_similar_type(actual.flat_string(), expected.flat_string(), is_call=True))
+            self.expr_err_count = 0
+
         if not all(matches) or len(call_args) != len(expected_types):
             self.errors.append(
                 MismatchedCallArgType(
                     global_type=global_type,
                     call_str=call_str,
                     id=id,
-                    id_definition=local_defs[call_str][0].id if call_str not in self.builtin_signatures else None,
+                    id_definition=local_defs[call_str][1] if call_str not in self.builtin_signatures else None,
                     expected_types=expected_types,
                     args=call_args,
                     actual_types=actual_types,

--- a/src/lexer/token.py
+++ b/src/lexer/token.py
@@ -175,7 +175,7 @@ class UniqueTokenType:
     ID = "ID"
     CWASS = "CWASS"
 
-    def __init__(self, lexeme: str, token: str):
+    def __init__(self, lexeme: str = '', token: str = ''):
         self._token = lexeme
         if token == self.ID:
             self._type = self.identifier_dict.setdefault(lexeme, f"IDENTIFIER_{len(self.identifier_dict) + 1}")

--- a/src/lexer/token.py
+++ b/src/lexer/token.py
@@ -29,6 +29,32 @@ class TokenType(Enum):
         return self.__str__()
     def flat_string(self, indent = 1):
         return self.__str__()
+    def python_string(self, indent = 1, cwass=False):
+        'should only be used for dtypes'
+        match self:
+            case TokenType.CHAN:
+                return "int"
+            case TokenType.CHAN_ARR:
+                return "Array"
+            case TokenType.KUN:
+                return "float"
+            case TokenType.KUN_ARR:
+                return "Array"
+            case TokenType.SAMA:
+                return "bool"
+            case TokenType.SAMA_ARR:
+                return "Array"
+            case TokenType.SAN:
+                return "NoneType"
+            case TokenType.SAN_ARR:
+                return "Array"
+            case TokenType.SENPAI:
+                return "String"
+            case TokenType.SENPAI_ARR:
+                return "Array"
+            case _:
+                raise ValueError(f"Unknown token: {self}")
+
     def header(self):
         return self.token
 

--- a/src/lexer/token.py
+++ b/src/lexer/token.py
@@ -175,7 +175,7 @@ class UniqueTokenType:
     ID = "ID"
     CWASS = "CWASS"
 
-    def __init__(self, lexeme: str = '', token: str = ''):
+    def __init__(self, lexeme: str = '', token: str = 'ID'):
         self._token = lexeme
         if token == self.ID:
             self._type = self.identifier_dict.setdefault(lexeme, f"IDENTIFIER_{len(self.identifier_dict) + 1}")
@@ -183,7 +183,7 @@ class UniqueTokenType:
         elif token == self.CWASS:
             self._type = self.cwass_dict.setdefault(lexeme, f"CWASS_{len(self.cwass_dict) + 1}")
             self._delim_id = "cwass"
-        self._expected_delims = DELIMS[self.delim_id]
+        self._expected_delims = DELIMS[self._delim_id]
 
     @classmethod
     def clear(cls):

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -385,6 +385,7 @@ class Assignment(Statement):
     def __init__(self):
         self.id: Token | IndexedIdentifier | ClassAccessor = Token() 
         self.value: Value = Value()
+        self.dtype: Token = Token()
 
     def header(self):
         return f"assign: {self.id.header()}"

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -519,7 +519,7 @@ class WhileLoop(Statement):
         res = ""
         if self.is_do:
             res = self.body.python_string(indent, cwass=cwass)
-        res += sprintln(f"while {self.condition.python_string(cwass=cwass)}:", indent=(indent if self.is_do else 0))
+        res += sprintln(f"while {self.condition.python_string(cwass=cwass)}:", indent=indent)
         res += self.body.python_string(indent+1, cwass=cwass)
         return res
 
@@ -555,6 +555,12 @@ class Parameter(Production):
     def __init__(self):
         self.id: Token = Token()
         self.dtype: Token = Token()
+        # always True
+        self.initialized = True
+        # always False
+        self.is_const: bool = False
+        # always EOF aka nothing
+        self.dono_token: Token = Token()
 
     def header(self):
         return f"id: {self.id.string()}, dtype: {self.dtype.string()}"

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -1,4 +1,4 @@
-from src.lexer.token import TokenType, class_properties
+from src.lexer.token import TokenType, UniqueTokenType, class_properties
 from src.parser.production_types import *
 from src.lexer import Token
 
@@ -334,6 +334,8 @@ class Declaration(Statement):
             if self.id.python_string(cwass=cwass) in class_properties:
                 res = "self."
         res += f"{self.id.python_string(cwass=cwass)}: {self.dtype.python_string(cwass=cwass)}"
+        if self.is_param: return res
+
         if self.initialized:
             if self.dtype.token == TokenType.CHAN:
                 # convert value to floats first then to int
@@ -351,7 +353,7 @@ class Assignment(Statement):
     def __init__(self):
         self.id: Token | IndexedIdentifier | ClassAccessor = Token() 
         self.value: Value = Value()
-        self.dtype: Token = Token()
+        self.dtype: TokenType | UniqueTokenType = TokenType.EOF # placeholder
 
     def header(self):
         return f"assign: {self.id.header()}"
@@ -372,7 +374,8 @@ class Assignment(Statement):
             global class_properties
             if self.id.python_string(cwass=cwass) in class_properties:
                 res = "self."
-        res += f"{self.id.python_string(cwass=cwass)} = {self.value.python_string(cwass=cwass)}"
+        if not self.dtype.exists(): raise Exception(f"UNREACHABLE::no dtype for assignment: '{self.id.flat_string()}'")
+        res += f"{self.id.python_string(cwass=cwass)} = {self.dtype.python_string(cwass=cwass)}({self.value.python_string(cwass=cwass)})"
         return sprint(res, indent=indent)
 
     def __len__(self):

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -664,7 +664,7 @@ class Program:
     def python_string(self, indent=0, cwass=False) -> str:
         res = ""
         for g in self.globals:
-            res += g.python_string(indent, cwass=cwass)
+            res += sprintln(g.python_string(indent, cwass=cwass))
         for c in self.classes:
             res += c.python_string(indent, cwass=cwass)
         for fn in self.functions:

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -299,7 +299,7 @@ class ReturnStatement(Statement):
     def string(self, indent = 0) -> str:
         return sprintln("return", self.expr.string(indent), indent=indent)
     def python_string(self, indent=0, cwass=False) -> str:
-        return sprintln("return", self.expr.python_string(indent, cwass=cwass), indent=indent)
+        return sprint("return", self.expr.python_string(indent, cwass=cwass), indent=indent)
     def __len__(self):
         return 1
 
@@ -343,7 +343,7 @@ class Declaration(Statement):
                 res += f" = {self.dtype.python_string(cwass=cwass)}({self.value.python_string(cwass=cwass)})"
         else:
             res += f" = None"
-        return sprintln(res, indent=indent)
+        return sprint(res, indent=indent)
 
 class ArrayDeclaration(Statement):
     def __init__(self):
@@ -379,7 +379,7 @@ class ArrayDeclaration(Statement):
             res += f" = {self.value.python_string(cwass=cwass)}"
         else:
             res += f" = None"
-        return sprintln(res, indent=indent)
+        return sprint(res, indent=indent)
 
 class Assignment(Statement):
     def __init__(self):
@@ -406,7 +406,7 @@ class Assignment(Statement):
             if self.id.python_string(cwass=cwass) in class_properties:
                 res = "self."
         res += f"{self.id.python_string(cwass=cwass)} = {self.value.python_string(cwass=cwass)}"
-        return sprintln(res, indent=indent)
+        return sprint(res, indent=indent)
 
     def __len__(self):
         return 1
@@ -434,7 +434,7 @@ class Print(Statement):
         for v in self.values:
             res += f"{v.python_string(cwass=cwass)}, "
         res = res[:-2] + ")"
-        return sprintln(res, indent=indent)
+        return sprint(res, indent=indent)
 
 class IfStatement(Statement):
     def __init__(self):
@@ -544,7 +544,7 @@ class ForLoop(Statement):
         return res
 
     def python_string(self, indent=0, cwass=False) -> str:
-        res = self.init.python_string(indent=indent)
+        res = sprintln(self.init.python_string(indent=indent))
         res += sprintln(f"while {self.condition.python_string(cwass=cwass)}:", indent=indent)
         res += self.body.python_string(indent+1, cwass=cwass)
         res += sprintln(f"{self.init.id.python_string(cwass=cwass)} = {self.update.python_string(cwass=cwass)}", indent=indent+1)

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -341,7 +341,7 @@ class Declaration(Statement):
                 # convert value to floats first then to int
                 # this for strings being float strings but passed as int
                 res += f" = {self.dtype.python_string(cwass=cwass)}(float({self.value.python_string(cwass=cwass)}))"
-            elif self.dtype.is_unique_type() or self.dtype.is_arr_type():
+            elif self.dtype.is_unique_type() or self.dtype.is_arr_type() or self.dtype.token == TokenType.SENPAI:
                 res += f" = {self.value.python_string(cwass=cwass)}"
             else:
                 res += f" = {self.dtype.python_string(cwass=cwass)}({self.value.python_string(cwass=cwass)})"
@@ -375,7 +375,15 @@ class Assignment(Statement):
             if self.id.python_string(cwass=cwass) in class_properties:
                 res = "self."
         if not self.dtype.exists(): raise Exception(f"UNREACHABLE::no dtype for assignment: '{self.id.flat_string()}'")
-        res += f"{self.id.python_string(cwass=cwass)} = {self.dtype.python_string(cwass=cwass)}({self.value.python_string(cwass=cwass)})"
+        res += f"{self.id.python_string(cwass=cwass)}"
+        if self.dtype.token == TokenType.CHAN:
+            # convert value to floats first then to int
+            # this for strings being float strings but passed as int
+            res += f" = {self.dtype.python_string(cwass=cwass)}(float({self.value.python_string(cwass=cwass)}))"
+        elif self.dtype.is_unique_type() or self.dtype.is_arr_type() or self.dtype == TokenType.SENPAI:
+            res += f" = {self.value.python_string(cwass=cwass)}"
+        else:
+            res += f" = {self.dtype.python_string(cwass=cwass)}({self.value.python_string(cwass=cwass)})"
         return sprint(res, indent=indent)
 
     def __len__(self):


### PR DESCRIPTION
closes #163

---

# fn calls 
### analyzer
- uninitialized vars/consts have underlying type `san` instead of what they're declared with
- during assignment/declaration, if any errors happen in evaluating the assigned value (if any), they are uninitialized
  - this makes it so they have an underlying type of `san`
- san values are no longer a valid math operand
  - can only use equality operators
### parser
- combine `ArrayDeclaration` `Parameter` and `Declaration` into just `Declaration`  with a `is_param` bool to differentiate
  - tbh this is just for easier type checking since these are essentially the same
- `Assignment` wraps its value with its dtype now
  - dtype is assigned during type checking
- `Assignment` and `Declaration` now avoid double wrapping `String` on string types
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/fe618221-df4b-4b75-8ac9-82ae87a865ab)
- indent while loop properly

### lexer
- default initialization of `UniqueTokenType`
- TokenTypes (the dtypes only) can be converted to python equivalent.
  - this is only used in assignments when wrapping its value
