### PR TITLE
feat: add underscore to ids to avoid python keyword collision

### DIFF
--- a/src/lexer/token.py
+++ b/src/lexer/token.py
@@ -292,7 +292,7 @@ class Token:
                 res = ""
                 if cwass and self.lexeme in class_properties:
                     res = "self."
-                res += self.lexeme
+                res += f"_{self.lexeme}"
                 return res
             case (TokenType.GWOBAW
                 | TokenType.DONO


### PR DESCRIPTION
closes #172 
because in uwu, you can have identifiers named `return` `print` `input` `for` and other python keywords. this is just to avoid collision in transpilation

# before
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/f37df498-bb93-4428-8a56-f908121eb6ec)

# after
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/26a561c3-5cf4-44ca-a5ed-fd10516f0992)
