### PR TITLE
fix: only inpwts with no concats can be converted to num types

### DIFF
--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -614,9 +614,13 @@ class TypeChecker:
         for arg, expected in zip(call_args, expected_types):
             match arg:
                 case Token():
-                    actual_def = local_defs[arg.flat_string()][0]
-                    actual = actual_def.dtype
-                    if not actual_def.initialized: actual = TokenType.SAN
+                    match arg.token:
+                        case UniqueTokenType():
+                            actual_def = local_defs[arg.flat_string()][0]
+                            actual = actual_def.dtype
+                            if not actual_def.initialized: actual = TokenType.SAN
+                        case TokenType():
+                            actual = self.evaluate_token(arg, local_defs)
                 case _:
                     actual = self.evaluate_value(arg, local_defs)
             actual_types.append(actual)

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -250,7 +250,12 @@ class TypeChecker:
         match expected_type.token:
             case TokenType():
                 actual_type = self.evaluate_value(value, local_defs)
-                if not self.is_similar_type(actual_type.flat_string(), expected_type.flat_string()):
+                match value:
+                    case Input():
+                        if not value.concats: actual_type_str = "inpwt"
+                        else: actual_type_str = "senpai"
+                    case _: actual_type_str = actual_type.flat_string()
+                if not self.is_similar_type(actual_type_str, expected_type.flat_string()):
                     self.errors.append(
                         TypeMismatchError(
                             expected=expected_type,
@@ -713,8 +718,8 @@ class TypeChecker:
             # num types are convertible between each other
             case "chan" | "kun":
                 match actual_type:
-                    # string can be converted to num, runtime error if cannot convert
-                    case "chan" | "kun" | "sama" | "senpai": return True
+                    # inpwts with no concats can be converted to num types
+                    case "chan" | "kun" | "sama" | "inpwt": return True
                     case _: return False
             # all types are convertible to bool
             case "sama": return True

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -112,7 +112,10 @@ class Input(Iterable):
     def string(self, indent = 0) -> str:
         return self.flat_string()
     def flat_string(self) -> str:
-        return f"input({self.expr.flat_string()}) & {' & '.join(c.flat_string() for c in self.concats)}"
+        res = f"input({self.expr.flat_string()})"
+        if self.concats:
+            res += ' & ' + ' & '.join(c.flat_string() for c in self.concats)
+        return res
     def python_string(self, indent=0, cwass=False) -> str:
         res = f"input({self.expr.python_string(cwass=cwass)})"
         if self.concats:

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -88,7 +88,10 @@ class StringLiteral(Iterable):
     def string(self, indent = 0) -> str:
         return self.flat_string()
     def flat_string(self) -> str:
-        return sprint(self.val.flat_string(), *[c.flat_string() for c in self.concats])
+        res = sprint(self.val.flat_string(), *[c.flat_string() for c in self.concats])
+        if self.concats:
+            res += ' & ' + ' & '.join(c.flat_string() for c in self.concats)
+        return res
     def python_string(self, indent=0, cwass=False) -> str:
         res = self.val.python_string(cwass=cwass)
         if self.concats:
@@ -141,7 +144,10 @@ class StringFmt(Iterable):
     def string(self, indent = 0) -> str:
         return self.flat_string()
     def flat_string(self) -> str:
-        return f"{self.start.flat_string()}{' '.join(m.flat_string() for m in self.mid_expr_iter())}{self.end.flat_string()}"
+        res = f"{self.start.flat_string()}{' '.join(m.flat_string() for m in self.mid_expr_iter())}{self.end.flat_string()}"
+        if self.concats:
+            res += ' & ' + ' & '.join(c.flat_string() for c in self.concats)
+        return res
     def python_string(self, indent=0, cwass=False) -> str:
         res = f"{self.start.python_string(cwass=cwass)}{' '.join(m.python_string(cwass=cwass) for m in self.mid_expr())}{self.end.python_string(cwass=cwass)}"
         if self.concats:


### PR DESCRIPTION
# before
- all strings are converted implicitly to num types
# after
- only `inpwt` with no concats can be converted to num types
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/515a7689-a81b-43e4-a2dc-dd0647ac2642)
