### PR TITLE
fix: when evaluating array errored, treat it as `san[]`, not `san`

### DIFF
--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -553,7 +553,7 @@ class TypeChecker:
                 flat_arr, units_type = self.expect_homogenous(collection, local_defs)
                 for val in flat_arr:
                     self.evaluate_value(val, local_defs)
-                return units_type.to_arr_type() if units_type != TokenType.SAN else TokenType.SAN
+                return units_type.to_arr_type()
             case StringFmt():
                 for val in collection.exprs:
                     self.evaluate_value(val, local_defs)
@@ -688,7 +688,7 @@ class TypeChecker:
                 HeterogeneousArrayError(arr, flat_arr, types)
             )
             return [], TokenType.SAN
-        return flat_arr, types.pop() if types else TokenType.SAN
+        return flat_arr, types.pop() if types else TokenType.SAN_ARR
 
     def flatten_array(self, arr: list[Value]) -> list[Value]:
         res = []


### PR DESCRIPTION
This is because all types can accept `san` during assignment and declaration so treating it as `san` will hide the type mismatch errors

# before
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/8eb4da6b-2589-44ab-a302-a9ffc6a0ebdf)

# after
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/c2f987b0-1ba5-403d-9cff-564a396d9dc6)
