### PR TITLE
Feat/clearer decl assign error msgs

### DIFF
--- a/src/analyzer/error_handler.py
+++ b/src/analyzer/error_handler.py
@@ -341,7 +341,7 @@ class InfixOperandError:
                f'{(q + self.right.flat_string() + q) if self.right_type else ""}'
                "\n")
         msg += border
-        if self.left_definition:
+        if self.left_definition and self.left_type:
             lhs_index = str(self.left_definition.position[0] + 1)
             msg += f"\n\t{' ' * max_pad} | \t"
             msg += Styled.sprintln(
@@ -366,7 +366,7 @@ class InfixOperandError:
                 msg += '\n'
         if self.left_type and self.right_type:
             msg += f"\t{' ' * max_pad} |"
-        if self.right_definition:
+        if self.right_definition and self.right_type:
             rhs_index = str(self.right_definition.position[0] + 1)
             msg += f"\n\t{' ' * max_pad} | \t"
             msg += Styled.sprintln(

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -258,10 +258,11 @@ class TypeChecker:
                 if not self.is_similar_type(actual_type_str, expected_type.flat_string()):
                     self.errors.append(
                         TypeMismatchError(
+                            title="Assignment" if assignment else "Declaration",
                             expected=expected_type,
                             actual_val=value,
                             actual_type=actual_type,
-                            assignment=assignment,
+                            context=assign if assignment else decl,
                         )
                     )
             case UniqueTokenType():
@@ -274,10 +275,11 @@ class TypeChecker:
                         if not self.is_similar_type(actual_type.flat_string(), expected_type.flat_string()):
                             self.errors.append(
                                 TypeMismatchError(
+                                    title="Assignment" if assignment else "Declaration",
                                     expected=expected_type,
                                     actual_val=value,
                                     actual_type=actual_type,
-                                    assignment=assignment,
+                                    context=assign if assignment else decl,
                                 )
                             )
         # (DECLARATION & ASSIGNMENT) uninitialize identifiers if any errors occured in evaluating value

--- a/src/style/style.py
+++ b/src/style/style.py
@@ -15,7 +15,7 @@ class AnsiColor(Enum):
         Yields colors in order. This loops back to first color after last color.
         This is intended to be used with next(), not in a loop.
         '''
-        colors = [AnsiColor.RED, AnsiColor.GREEN, AnsiColor.YELLOW, AnsiColor.BLUE, AnsiColor.MAGENTA, AnsiColor.CYAN]
+        colors = [AnsiColor.YELLOW, AnsiColor.BLUE, AnsiColor.MAGENTA, AnsiColor.CYAN]
         while True:
             for color in colors:
                 yield color


### PR DESCRIPTION
closes #171 

- used to only show the value but now it shows the entire statement so its clearer _what_ went wrong.
- now shows where the line number of the statement is so its clearer _where_ things went wrong
  - technically its only the line number of the id since there are situations where values can end up in multiple lines like
  ```
  a-chan[] = {1,2,3,4,
              5,6,7,8
              9,10,11,12}
  b-chan = someFunction(
                 arg1,
                 arg2,
                 arg3
           )
  ```
  - the value assigned is flattened though so the error message still sees the entire value, even it if spans multiple lines

# before
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/a5cffa4d-d96b-450c-99bb-9816980e17be)
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/53fe03bb-9f14-44b8-b160-df0008e8cae1)

# after
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/8910d89b-f1bd-41b6-9d87-89576b17f73c)
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/f8ef7688-c9c9-4b31-9cc4-106bcd842a8f)
