### PR TITLE
fix: properly check for homogeneous arrays for unique token types

### DIFF
--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -694,7 +694,7 @@ class TypeChecker:
                     types.append(self.evaluate_iterable(val, local_defs))
                 case _:
                     raise ValueError(f"Unknown array value type: {val.flat_string()}")
-        if len(set(types)) > 1:
+        if len(set([t.flat_string() for t in types])) > 1:
             self.errors.append(
                 HeterogeneousArrayError(arr, flat_arr, types)
             )


### PR DESCRIPTION
unique token types are actually unique, even if they're the same type. comparison is made as strings now.

# before
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/e35cc32c-7a80-4813-8f0e-ad1f7b6ed70b)

# after
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/f8558fc1-97e6-4927-90d7-16dff57db35d)
