### PR TITLE
Fix/builtin type method underscores

### DIFF
--- a/src/builtin/types/types.py
+++ b/src/builtin/types/types.py
@@ -59,15 +59,15 @@ class String:
         return iter(self.val)
 
     ## BUILTIN METHODS
-    def len(self) -> int:
+    def _len(self) -> int:
         return self.__len__()
-    def reversed(self) -> Self:
+    def _reversed(self) -> Self:
         return type(self)(self.val[::-1])
-    def has(self, item: str) -> bool:
+    def _has(self, item: str) -> bool:
         return item in self.val
-    def upper(self) -> Self:
+    def _upper(self) -> Self:
         return type(self)(self.val.upper())
-    def lower(self) -> Self:
+    def _lower(self) -> Self:
         return type(self)(self.val.lower())
 
     ## UTILS
@@ -120,9 +120,9 @@ class Array:
         return iter(self.val)
 
     ## BUILTIN METHODS
-    def len(self) -> int:
+    def _len(self) -> int:
         return self.__len__()
-    def reverse(self) -> None:
+    def _reverse(self) -> None:
         self.val = self.val[::-1]
 
     ## UTILS

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -350,7 +350,7 @@ class Declaration(Statement):
                 # convert value to floats first then to int
                 # this for strings being float strings but passed as int
                 res += f" = {self.dtype.python_string(cwass=cwass)}(float({self.value.python_string(cwass=cwass)}))"
-            elif self.dtype.is_unique_type() or self.dtype.is_arr_type() or self.dtype.token == TokenType.SENPAI:
+            elif self.dtype.is_unique_type() or self.dtype.is_arr_type():
                 res += f" = {self.value.python_string(cwass=cwass)}"
             else:
                 res += f" = {self.dtype.python_string(cwass=cwass)}({self.value.python_string(cwass=cwass)})"
@@ -389,7 +389,7 @@ class Assignment(Statement):
             # convert value to floats first then to int
             # this for strings being float strings but passed as int
             res += f" = {self.dtype.python_string(cwass=cwass)}(float({self.value.python_string(cwass=cwass)}))"
-        elif self.dtype.is_unique_type() or self.dtype.is_arr_type() or self.dtype == TokenType.SENPAI:
+        elif self.dtype.is_unique_type() or self.dtype.is_arr_type():
             res += f" = {self.value.python_string(cwass=cwass)}"
         else:
             res += f" = {self.dtype.python_string(cwass=cwass)}({self.value.python_string(cwass=cwass)})"


### PR DESCRIPTION
### changes
- bulitin type methods are prepended with underscore so you can use it now when compiled
- assignments and declarations wrap senpai values with String
  - idk why it didn't, idk why I made an exception to senpai