### PR TITLE
Fix/global initialization

### DIFF
--- a/src/analyzer/analyzer.py
+++ b/src/analyzer/analyzer.py
@@ -17,6 +17,8 @@ class MemberAnalyzer:
 
     def analyze_program(self) -> None:
         assert self.program.mainuwu
+        for global_dec in self.program.globals:
+            self.analyze_declaration(global_dec, self.global_names)
         self.analyze_function(self.program.mainuwu, self.global_names.copy())
         for func in self.program.functions:
             self.analyze_function(func, self.global_names.copy())
@@ -28,16 +30,6 @@ class MemberAnalyzer:
         populates the self.global_names dict with the unique global names
         any duplicates will be appended to error
         '''
-        self.global_names: dict[str, tuple[Token, GlobalType]] = {}
-        for global_dec in self.program.globals:
-            if global_dec.id.string() in self.global_names:
-                self.errors.append(DuplicateDefinitionError(
-                    *self.global_names[global_dec.id.string()],
-                    global_dec.id,
-                    GlobalType.IDENTIFIER,
-                ))
-            else:
-                self.global_names[global_dec.id.string()] = (global_dec.id, GlobalType.IDENTIFIER)
         for func in self.program.functions:
             if func.id.string() in self.global_names:
                 self.errors.append(DuplicateDefinitionError(

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -699,7 +699,7 @@ class Program:
         res += sprintln("import os", indent=indent+1)
         res += sprintln("os.system('cls' if platform.system() == 'Windows' else 'clear')", indent=indent+1)
         res += sprintln()
-        res += sprintln("# declare as None first", indent=indent+1)
+        res += sprintln("# declare globals", indent=indent+1)
         for g in self.globals:
             res += sprintln(g.python_string(cwass=cwass), indent=indent+1)
         res += sprintln("main()", indent=indent+1)

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -687,18 +687,21 @@ class Program:
 
     def python_string(self, indent=0, cwass=False) -> str:
         res = ""
-        for g in self.globals:
-            res += sprintln(g.python_string(indent, cwass=cwass))
+        if self.mainuwu:
+            res += self.mainuwu.python_string(indent, cwass=cwass)
         for c in self.classes:
             res += c.python_string(indent, cwass=cwass)
         for fn in self.functions:
             res += fn.python_string(indent, cwass=cwass)
-        if self.mainuwu:
-            res += self.mainuwu.python_string(indent, cwass=cwass)
         res += sprintln("if __name__ == '__main__':", indent=indent)
+        res += sprintln("# clear screen before executing", indent=indent+1)
         res += sprintln("import platform", indent=indent+1)
         res += sprintln("import os", indent=indent+1)
         res += sprintln("os.system('cls' if platform.system() == 'Windows' else 'clear')", indent=indent+1)
+        res += sprintln()
+        res += sprintln("# declare as None first", indent=indent+1)
+        for g in self.globals:
+            res += sprintln(g.python_string(cwass=cwass), indent=indent+1)
         res += sprintln("main()", indent=indent+1)
         return res
 


### PR DESCRIPTION
closes #203 

---

### changes
1. global declarations are defined sequentially
  - this means below (which was previously valid) is no longer valid
  ```
   gwobaw a-chan = b~
   gwobaw b-chan = c~
   gwobaw c-chan = 10~
  ```
2. global declarations in transpiled output is now defined inside the `if __name__ == "__main__"` block
  - before
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/4b85f044-ff48-4f63-ad09-ce4b5111ee68)

  - after
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/56491858-3fea-4643-aa8c-7b3257b0d1d5)
