### PR TITLE
Feat/append and has builtin method

### DIFF
--- a/src/analyzer/__main__.py
+++ b/src/analyzer/__main__.py
@@ -1,3 +1,4 @@
+import re
 from .type_checker import TypeChecker
 from .error_handler import ErrorSrc
 from .analyzer import MemberAnalyzer
@@ -7,28 +8,28 @@ from src.parser.error_handler import ErrorSrc as parErrorSrc
 
 if __name__ == "__main__":
     sc = """
-    cwass Hololive() [[ a-san~ ]]
+    cwass Hololive() [[
+        b-chan~
+    ]]
     fwunc mainuwu-san() [[
-        a-chan[] = {nuww}~
-        a = {nuww}~
-        b-chan[] = {}~
-        b = {}~
-        c-Hololive[] = {nuww}~
-        c = {nuww}~
-        d-Hololive[] = {}~
-        d = {}~
-        z-chan~
-        y-chan[] = {z}~
-        sum({})~
-        sum({nuww})~
-    ]]
-    fwunc sum-chan[](num-chan[]) [[
-        wetuwn({nuww})~
-    ]]
-    fwunc sum2-chan[](num-chan[]) [[
-        wetuwn({})~
+        a-Hololive[] = {}~
+        a.append(Hololive())~
+        a.append(1)~
+        a.has(Hololive())~
+        a.has(1)~
+        z-chan[] = {1,2,3}~
+        z.append(10)~
+        z.has(10)~
+        z.append("")~
+        z.has("")~
+        x-senpai[] = {}~
+        x.append(10)~
+        x.has(10)~
+        x.append("")~
+        x.has("")~
     ]]
     """
+    sc = re.sub(r"[\0\1]", "", sc)
     source: list[str] = [line if line else '\n' for line in sc.split("\n")]
     max_digit_length = len(str(len(source)))
     max_width = max(len(line) for line in source) + max_digit_length + 3
@@ -36,7 +37,7 @@ if __name__ == "__main__":
     print("-"*max_width)
     for i, line in enumerate(source):
         line = line if line != '\n' else ''
-        print(f"{i+1} | {line}")
+        print(f"{i+1:{max_digit_length}} | {line}")
     print("-"*max_width)
     print('end of file\n')
 

--- a/src/analyzer/error_handler.py
+++ b/src/analyzer/error_handler.py
@@ -515,7 +515,7 @@ class UndefinedClassMember:
 
 class MismatchedCallArgType:
     def __init__(self, global_type: GlobalType, call_str: str, id: Token, id_definition: Token|None,
-                 expected_types: list[Token], args: list[Value], actual_types: list[TokenType], matches: list[bool]
+                 expected_types: list[str], args: list[Value], actual_types: list[TokenType], matches: list[bool]
                  ) -> None:
         self.global_type = global_type
         self.call_str = call_str
@@ -565,7 +565,7 @@ class MismatchedCallArgType:
         )
         max_type_pad = 4 + len(AnsiColor.RED.value)*2
         if self.expected_types:
-            max_type_pad += max(len(expected.flat_string()) for expected in self.expected_types)
+            max_type_pad += max(len(expected) for expected in self.expected_types)
         msg += f"\t{' ' * max_pad} |\t"
         msg += f'{Styled.sprint("EXPECTED", color=AnsiColor.CYAN):{max_type_pad}} '
         msg += f'{Styled.sprint("ACTUAL", color=AnsiColor.CYAN):{max_type_pad+2}}'
@@ -574,7 +574,7 @@ class MismatchedCallArgType:
             color = AnsiColor.GREEN if matched else AnsiColor.RED
             res = '✓' if matched else '✗'
             msg += f"\t{' ' * max_pad} |\t" + (
-                f"{Styled.sprint(res, expected.flat_string(), color=color):{max_type_pad}} {Styled.sprint('(', actual.flat_string(), ')', color=color):{max_type_pad+2}}"+
+                f"{Styled.sprint(res, expected, color=color):{max_type_pad}} {Styled.sprint('(', actual.flat_string(), ')', color=color):{max_type_pad+2}}"+
                 Styled.sprint(arg.flat_string(), color=color)+
                 "\n"
             )
@@ -589,7 +589,7 @@ class MismatchedCallArgType:
                 )
                 for i in range(len(self.actual_types), len(self.expected_types)):
                     msg += f"\t{' ' * max_pad} |\t" + (
-                        f"{Styled.sprint('✗', self.expected_types[i].flat_string(), color=AnsiColor.RED):{max_type_pad}} {Styled.sprint('(', 'MISSING', ')', color=AnsiColor.RED):{max_type_pad+2}}\n"
+                        f"{Styled.sprint('✗', self.expected_types[i], color=AnsiColor.RED):{max_type_pad}} {Styled.sprint('(', 'MISSING', ')', color=AnsiColor.RED):{max_type_pad+2}}\n"
                     )
             elif actual_len > expected_len:
                 msg += Styled.sprintln(

--- a/src/analyzer/error_handler.py
+++ b/src/analyzer/error_handler.py
@@ -563,18 +563,22 @@ class MismatchedCallArgType:
             (f" but was called with {len(self.args)}" if len(self.expected_types) != len(self.actual_types) else ""),
             color=AnsiColor.CYAN
         )
-        max_type_pad = 4 + len(AnsiColor.RED.value)*2
+        expected_pad = actual_pad = 4 + len(AnsiColor.RED.value)*2
         if self.expected_types:
-            max_type_pad += max(len(expected) for expected in self.expected_types)
+            expected_pad += max(max(len(expected) for expected in self.expected_types), 8)
+        if self.actual_types:
+            actual_pad += max(max(len(actual.flat_string()) for actual in self.actual_types), 6)
+
         msg += f"\t{' ' * max_pad} |\t"
-        msg += f'{Styled.sprint("EXPECTED", color=AnsiColor.CYAN):{max_type_pad}} '
-        msg += f'{Styled.sprint("ACTUAL", color=AnsiColor.CYAN):{max_type_pad+2}}'
+        msg += f'{Styled.sprint("EXPECTED", color=AnsiColor.CYAN):{expected_pad-1}} '
+        msg += f'{Styled.sprint("ACTUAL", color=AnsiColor.CYAN):{actual_pad-1}} '
         msg += f'{Styled.sprint("ARG", color=AnsiColor.CYAN)}\n'
+
         for expected, actual, arg, matched in zip(self.expected_types, self.actual_types, self.args, self.matches):
             color = AnsiColor.GREEN if matched else AnsiColor.RED
             res = '✓' if matched else '✗'
             msg += f"\t{' ' * max_pad} |\t" + (
-                f"{Styled.sprint(res, expected, color=color):{max_type_pad}} {Styled.sprint('(', actual.flat_string(), ')', color=color):{max_type_pad+2}}"+
+                f"{Styled.sprint(res, expected, color=color):{expected_pad}}{Styled.sprint(actual.flat_string(), color=color):{actual_pad}}"+
                 Styled.sprint(arg.flat_string(), color=color)+
                 "\n"
             )
@@ -589,7 +593,7 @@ class MismatchedCallArgType:
                 )
                 for i in range(len(self.actual_types), len(self.expected_types)):
                     msg += f"\t{' ' * max_pad} |\t" + (
-                        f"{Styled.sprint('✗', self.expected_types[i], color=AnsiColor.RED):{max_type_pad}} {Styled.sprint('(', 'MISSING', ')', color=AnsiColor.RED):{max_type_pad+2}}\n"
+                        f"{Styled.sprint('✗', self.expected_types[i], color=AnsiColor.RED):{expected_pad}} {Styled.sprint('(', 'MISSING', ')', color=AnsiColor.RED):{actual_pad}}\n"
                     )
             elif actual_len > expected_len:
                 msg += Styled.sprintln(
@@ -598,7 +602,7 @@ class MismatchedCallArgType:
                 )
                 for i in range(len(self.expected_types), len(self.args)):
                     msg += f"\t{' ' * max_pad} |\t" + (
-                        f"{Styled.sprint('✗', 'NONE', color=AnsiColor.RED):{max_type_pad}} {Styled.sprint('(', self.args[i].flat_string(), ')', color=AnsiColor.RED):{max_type_pad+2}}"
+                        f"{Styled.sprint('✗', 'NONE', color=AnsiColor.RED):{expected_pad}} {Styled.sprint('(', self.args[i].flat_string(), ')', color=AnsiColor.RED):{actual_pad}}"
                         f"{Styled.sprint(self.args[i].flat_string(), color=AnsiColor.RED)}\n"
                     )
         msg += border

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -635,7 +635,7 @@ class TypeChecker:
                     actual = self.evaluate_value(arg, local_defs)
             actual_types.append(actual)
             if expected.token == TokenType.ARRAY_ELEMENT:
-                matches.append(self.is_element_of_expected(actual, self_type if self_type.exists() else expected.token))
+                matches.append(self.is_element_of_expected(actual, self_type if self_type.exists() else expected.token, arg))
             else:
                 matches.append(self.is_similar_type(actual.flat_string(), expected.flat_string(), arg, is_call=True))
 
@@ -759,12 +759,21 @@ class TypeChecker:
                 # every other type needs exact match
                 return False
 
-    def is_element_of_expected(self, actual_type: TokenType, expected_type: TokenType) -> bool:
+    def is_element_of_expected(self, actual_type: TokenType, expected_type: TokenType, val: Value) -> bool:
         'determines if a type is self'
-        return (actual_type.flat_string() == expected_type.flat_string()
-            or actual_type.to_arr_type().flat_string() == expected_type.flat_string()
-            or actual_type.to_unit_type().flat_string() == expected_type.flat_string()
-        )
+        actual, actual_arr, actual_unit = actual_type.flat_string(), actual_type.to_arr_type().flat_string(), actual_type.to_unit_type().flat_string()
+        expected = expected_type.flat_string()
+        if (actual == expected
+            or actual_arr == expected
+            or actual_unit == expected
+            ): return True
+
+        if ("san[]" in [actual, actual_arr]
+            and isinstance(val, ArrayLiteral)
+            and len(val.elements) == 0):
+            return True
+
+        return False
 
     def is_accessible(self, actual_type: TokenType) -> bool:
         'determines if a type is accessable'

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -76,7 +76,7 @@ class TypeChecker:
 
                 'array_type.len': [],
                 'array_type.reverse': [],
-                'array_type.append': [Token('gen_arr', TokenType.GENERAL_ARRAY)],
+                'array_type.append': [Token('elem', TokenType.ARRAY_ELEMENT)],
             }
         )
 
@@ -631,13 +631,13 @@ class TypeChecker:
                 case _:
                     actual = self.evaluate_value(arg, local_defs)
             actual_types.append(actual)
-            if expected.token == TokenType.GENERAL_ARRAY:
-                matches.append(self.is_self_type(actual, self_type if self_type.exists() else expected.token))
+            if expected.token == TokenType.ARRAY_ELEMENT:
+                matches.append(self.is_element_of_expected(actual, self_type if self_type.exists() else expected.token))
             else:
                 matches.append(self.is_similar_type(actual.flat_string(), expected.flat_string(), arg, is_call=True))
 
         if not all(matches) or len(call_args) != len(expected_types):
-            expected_types_str: list[str] = [f"{e.token}" if e.token != TokenType.GENERAL_ARRAY else f"{self_type.to_unit_type()} or {self_type.to_arr_type()}" for e in expected_types ]
+            expected_types_str: list[str] = [f"{e.token}" if e.token != TokenType.ARRAY_ELEMENT else f"{self_type.to_unit_type()} or {self_type.to_arr_type()}" for e in expected_types ]
             self.errors.append(
                 MismatchedCallArgType(
                     global_type=global_type,
@@ -756,7 +756,7 @@ class TypeChecker:
                 # every other type needs exact match
                 return False
 
-    def is_self_type(self, actual_type: TokenType, expected_type: TokenType) -> bool:
+    def is_element_of_expected(self, actual_type: TokenType, expected_type: TokenType) -> bool:
         'determines if a type is self'
         return (actual_type.flat_string() == expected_type.flat_string()
             or actual_type.to_arr_type().flat_string() == expected_type.flat_string()

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -758,9 +758,9 @@ class TypeChecker:
 
     def is_self_type(self, actual_type: TokenType, expected_type: TokenType) -> bool:
         'determines if a type is self'
-        return (actual_type == expected_type
-            or actual_type.to_unit_type() == expected_type
-            or actual_type.to_arr_type() == expected_type
+        return (actual_type.flat_string() == expected_type.flat_string()
+            or actual_type.to_arr_type().flat_string() == expected_type.flat_string()
+            or actual_type.to_unit_type().flat_string() == expected_type.flat_string()
         )
 
     def is_accessible(self, actual_type: TokenType) -> bool:

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -52,6 +52,7 @@ class TypeChecker:
             'array_type.len',
             'array_type.reverse',
             'array_type.append',
+            'array_type.has',
         }
         self.class_signatures.update(
             {
@@ -63,6 +64,7 @@ class TypeChecker:
 
                 'array_type.len': (Declaration(), Token('chan', TokenType.CHAN), GlobalType.CLASS_METHOD),
                 'array_type.reverse': (Declaration(), Token('san', TokenType.SAN), GlobalType.CLASS_METHOD),
+                'array_type.has': (Declaration(), Token('sama', TokenType.SAMA), GlobalType.CLASS_METHOD),
                 'array_type.append': (Declaration(), Token('san', TokenType.SAN), GlobalType.CLASS_METHOD),
             },
         )
@@ -77,6 +79,7 @@ class TypeChecker:
                 'array_type.len': [],
                 'array_type.reverse': [],
                 'array_type.append': [Token('elem', TokenType.ARRAY_ELEMENT)],
+                'array_type.has': [Token('elem', TokenType.ARRAY_ELEMENT)],
             }
         )
 

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -583,12 +583,12 @@ class TypeChecker:
             case _:
                 raise ValueError(f"Unknown collection: {collection}")
 
-    def evaluate_method_call(self, class_id: Token, fn_call: FnCall, local_defs: dict[str, tuple[Declaration, Token, GlobalType]]) -> TokenType:
-        class_id_str = class_id.flat_string() if not class_id.token.is_arr_type() else 'array_type'
+    def evaluate_method_call(self, class_type: Token, fn_call: FnCall, local_defs: dict[str, tuple[Declaration, Token, GlobalType]]) -> TokenType:
+        class_id_str = class_type.flat_string() if not class_type.token.is_arr_type() else 'array_type'
         if (res := self.class_signatures.get(f"{class_id_str}.{fn_call.id.flat_string()}")) is None:
             self.errors.append(
                 UndefinedClassMember(
-                    class_id.flat_string(),
+                    class_type.flat_string(),
                     fn_call.id,
                     GlobalType.CLASS_METHOD,
                 )
@@ -598,7 +598,7 @@ class TypeChecker:
         if member_type != GlobalType.CLASS_METHOD:
             self.errors.append(
                 UndefinedClassMember(
-                    class_id.flat_string(),
+                    class_type.flat_string(),
                     fn_call.id,
                     GlobalType.CLASS_METHOD,
                     actual_definition=(return_type, member_type),

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -76,7 +76,7 @@ class TypeChecker:
 
                 'array_type.len': [],
                 'array_type.reverse': [],
-                'array_type.append': [Token('self', TokenType.SELF)],
+                'array_type.append': [Token('gen_arr', TokenType.GENERAL_ARRAY)],
             }
         )
 
@@ -631,13 +631,13 @@ class TypeChecker:
                 case _:
                     actual = self.evaluate_value(arg, local_defs)
             actual_types.append(actual)
-            if expected.token == TokenType.SELF:
+            if expected.token == TokenType.GENERAL_ARRAY:
                 matches.append(self.is_self_type(actual, self_type if self_type.exists() else expected.token))
             else:
                 matches.append(self.is_similar_type(actual.flat_string(), expected.flat_string(), arg, is_call=True))
 
         if not all(matches) or len(call_args) != len(expected_types):
-            expected_types_str: list[str] = [f"{e.token}" if e.token != TokenType.SELF else f"{self_type.to_unit_type()} or {self_type.to_arr_type()}" for e in expected_types ]
+            expected_types_str: list[str] = [f"{e.token}" if e.token != TokenType.GENERAL_ARRAY else f"{self_type.to_unit_type()} or {self_type.to_arr_type()}" for e in expected_types ]
             self.errors.append(
                 MismatchedCallArgType(
                     global_type=global_type,

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -751,6 +751,13 @@ class TypeChecker:
                 # every other type needs exact match
                 return False
 
+    def is_self_type(self, actual_type: TokenType, expected_type: TokenType) -> bool:
+        'determines if a type is self'
+        return (actual_type == expected_type
+            or actual_type.to_unit_type() == expected_type
+            or actual_type.to_arr_type() == expected_type
+        )
+
     def is_accessible(self, actual_type: TokenType) -> bool:
         'determines if a type is accessable'
         return actual_type.is_arr_type() or actual_type == TokenType.SENPAI

--- a/src/builtin/types/types.py
+++ b/src/builtin/types/types.py
@@ -124,6 +124,8 @@ class Array:
         return self.__len__()
     def _reverse(self) -> None:
         self.val = self.val[::-1]
+    def _append(self, item) -> None:
+        self.val.append(item)
 
     ## UTILS
     def valid_array_elems(self) -> list[type]:

--- a/src/builtin/types/types.py
+++ b/src/builtin/types/types.py
@@ -12,6 +12,8 @@ class String:
         return len(self.val)
     def __str__(self):
         return str(self.val)
+    def __repr__(self):
+        return repr(self.val)
 
     # operator overloading
     def __add__(self, other):

--- a/src/builtin/types/types.py
+++ b/src/builtin/types/types.py
@@ -4,14 +4,14 @@ class String:
     def __init__(self, val: str):
         expect_type_is_in(val, self.stringable_types(),
                                msg=f"OwO... that ain't stringable!")
-        self.val: str = val
+        self.val: str = str(val)
 
     ## META DUNDER METHODS
     # basic properties
     def __len__(self):
         return len(self.val)
     def __str__(self):
-        return self.val
+        return str(self.val)
 
     # operator overloading
     def __add__(self, other):

--- a/src/builtin/types/types.py
+++ b/src/builtin/types/types.py
@@ -126,6 +126,8 @@ class Array:
         self.val = self.val[::-1]
     def _append(self, item) -> None:
         self.val.append(item)
+    def _has(self, item) -> bool:
+        return item in self.val
 
     ## UTILS
     def valid_array_elems(self) -> list[type]:

--- a/src/lexer/token.py
+++ b/src/lexer/token.py
@@ -294,7 +294,7 @@ class Token:
                 global class_properties
                 res = ""
                 if self.token.is_arr_type(): return "Array"
-                if cwass and self.lexeme in class_properties:
+                if cwass and f"_{self.lexeme}" in class_properties:
                     res = "self."
                 res += f"_{self.lexeme}"
                 return res

--- a/src/lexer/token.py
+++ b/src/lexer/token.py
@@ -187,7 +187,7 @@ class TokenType(Enum):
     EOF = ("EOF", "all")
 
     # for `append()` type checking
-    GENERAL_ARRAY = ("gen_arr", "all")
+    ARRAY_ELEMENT = ("elem", "all")
 
 class UniqueTokenType:
     """

--- a/src/lexer/token.py
+++ b/src/lexer/token.py
@@ -253,11 +253,13 @@ class UniqueTokenType:
         return self.token
 
     def to_arr_type(self):
-        self._token += "[]"
-        return self
+        tmp = deepcopy(self)
+        tmp._token += "[]"
+        return tmp
     def to_unit_type(self):
-        self._token = self._token[:-2] if self._token.endswith("[]") else self._token
-        return self
+        tmp = deepcopy(self)
+        tmp._token = tmp._token[:-2] if tmp.is_arr_type() else tmp._token
+        return tmp
     def is_arr_type(self):
         return self.token.endswith("[]")
     def is_unique_type(self):

--- a/src/lexer/token.py
+++ b/src/lexer/token.py
@@ -186,7 +186,8 @@ class TokenType(Enum):
     WHITESPACE = ("WHITESPACE", "all")
     EOF = ("EOF", "all")
 
-    MIXED_ARRAY = ("MIXED_ARRAY", "all")
+    # for `append()` type checking
+    GENERAL_ARRAY = ("gen_arr", "all")
 
 class UniqueTokenType:
     """

--- a/src/lexer/token.py
+++ b/src/lexer/token.py
@@ -254,11 +254,11 @@ class UniqueTokenType:
 
     def to_arr_type(self):
         tmp = deepcopy(self)
-        tmp._token += "[]"
+        tmp._token += "[]" if not tmp._token.endswith("[]") else ""
         return tmp
     def to_unit_type(self):
         tmp = deepcopy(self)
-        tmp._token = tmp._token[:-2] if tmp.is_arr_type() else tmp._token
+        tmp._token = tmp._token.replace("[]", "")
         return tmp
     def is_arr_type(self):
         return self.token.endswith("[]")

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -418,9 +418,8 @@ class Print(Statement):
 
     def python_string(self, indent=0, cwass=False) -> str:
         res = "print("
-        for v in self.values:
-            res += f"{v.python_string(cwass=cwass)}, "
-        res = res[:-2] + ")"
+        res += f"{', '.join(v.python_string(cwass=cwass) for v in self.values)}"
+        res += ")"
         return sprint(res, indent=indent)
 
 class IfStatement(Statement):


### PR DESCRIPTION
closes #202 

---

### new
1. `append()` and `has()` builtin method for arrays are properly type checked
    - achieved using a tokentype `ARRAY_ELEMENT` which is a token type specifically for type checking
    - checks whether the arg type is a unit type or another array type (`chan`, `chan[]`) of the receiving param type (`chan[]`)
    - empty arrays (`{}`) can be an arg for `append()` and `has()` methods of any array type

### etc
- prevent cascading mutated references of `UniqueTokenTypes` by using `deepcopy()`
- empty `Print` production correctly transpiled now
- etc... various bugfixes

---

```python
sample text file
----------------------------------
 1 |
 2 |     cwass Hololive() [[
 3 |         b-chan~
 4 |     ]]
 5 |     fwunc mainuwu-san() [[
 6 |         a-Hololive[] = {}~
 7 |         a.append(Hololive())~
 8 |         a.append(1)~
 9 |         a.has(Hololive())~
10 |         a.has(1)~
11 |         z-chan[] = {1,2,3}~
12 |         z.append(10)~
13 |         z.has(10)~
14 |         z.append("")~
15 |         z.has("")~
16 |         x-senpai[] = {}~
17 |         x.append(10)~
18 |         x.has(10)~
19 |         x.append("")~
20 |         x.has("")~
21 |     ]]
22 |
----------------------------------
end of file

Call arg type mismatch:
        _________________________
          |
          |     'Hololive[].append()' called here
        8 |         a.append(1)~
          |           ^^^^^^
          |
          |     'Hololive[].append()' class method expects 1 argument
          |     EXPECTED                   ACTUAL     ARG
          |     ✗ Hololive or Hololive[]   chan       1
        _________________________

Call arg type mismatch:
        _______________________
           |
           |    'Hololive[].has()' called here
        10 |         a.has(1)~
           |           ^^^
           |
           |    'Hololive[].has()' class method expects 1 argument
           |    EXPECTED                   ACTUAL     ARG
           |    ✗ Hololive or Hololive[]   chan       1
        _______________________

Call arg type mismatch:
        ___________________________
           |
           |    'chan[].append()' called here
        14 |         z.append("")~
           |           ^^^^^^
           |
           |    'chan[].append()' class method expects 1 argument
           |    EXPECTED           ACTUAL     ARG
           |    ✗ chan or chan[]   senpai     ""
        ___________________________

Call arg type mismatch:
        ________________________
           |
           |    'chan[].has()' called here
        15 |         z.has("")~
           |           ^^^
           |
           |    'chan[].has()' class method expects 1 argument
           |    EXPECTED           ACTUAL     ARG
           |    ✗ chan or chan[]   senpai     ""
        ________________________

Call arg type mismatch:
        ___________________________
           |
           |    'senpai[].append()' called here
        17 |         x.append(10)~
           |           ^^^^^^
           |
           |    'senpai[].append()' class method expects 1 argument
           |    EXPECTED               ACTUAL     ARG
           |    ✗ senpai or senpai[]   chan       10
        ___________________________

Call arg type mismatch:
        ________________________
           |
           |    'senpai[].has()' called here
        18 |         x.has(10)~
           |           ^^^
           |
           |    'senpai[].has()' class method expects 1 argument
           |    EXPECTED               ACTUAL     ARG
           |    ✗ senpai or senpai[]   chan       10
        ________________________
```