### PR TITLE
String concat method

### DIFF
--- a/src/builtin/types/types.py
+++ b/src/builtin/types/types.py
@@ -71,6 +71,8 @@ class String:
         return type(self)(self.val.upper())
     def _lower(self) -> Self:
         return type(self)(self.val.lower())
+    def _concat(self, item: str) -> None:
+        self.val += str(item)
 
     ## UTILS
     def stringable_types(self) -> list[type]:

--- a/src/lexer/token.py
+++ b/src/lexer/token.py
@@ -189,6 +189,9 @@ class TokenType(Enum):
     # for `append()` type checking
     ARRAY_ELEMENT = ("elem", "all")
 
+    # for `concat()` type checking
+    STRINGABLE = ("str", "all")
+
 class UniqueTokenType:
     """
     A class for generating unique token types.


### PR DESCRIPTION
## Added concat() method for strings
- accepts any data type aside from san and san[]
- converts any data type to string before concatenating
- concats in place

## Usage
Source Code:
![image](https://github.com/Gidsss/UwUIDE/assets/66175571/2a187162-b3e1-458f-9544-a83b14dd98b5)
Output:
![image](https://github.com/Gidsss/UwUIDE/assets/66175571/9d1ba0dc-e2b1-4073-993d-158c32608bfb)

## Errors
Source Code:
![image](https://github.com/Gidsss/UwUIDE/assets/66175571/d2801342-0233-4e2f-84bf-69c33bf985ef)
Output:
![image](https://github.com/Gidsss/UwUIDE/assets/66175571/eeae2bde-e9de-49a0-aa94-d50bebac08ab)
