### PR TITLE
Feat/more array builtin methods

### DIFF
--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -70,6 +70,7 @@ class TypeChecker:
             'array_type.index',
             'array_type.pop',
             'array_type.prepend',
+            'array_type.prextend',
         }
         self.class_signatures.update(
             {
@@ -100,6 +101,7 @@ class TypeChecker:
                 'array_type.index': (Declaration(), Token('chan', TokenType.CHAN), GlobalType.CLASS_METHOD),
                 'array_type.pop': (Declaration(), Token('san', TokenType.SAN), GlobalType.CLASS_METHOD),
                 'array_type.prepend': (Declaration(), Token('san', TokenType.SAN), GlobalType.CLASS_METHOD),
+                'array_type.prextend': (Declaration(), Token('san', TokenType.SAN), GlobalType.CLASS_METHOD),
             },
         )
         self.class_method_param_types.update(
@@ -131,6 +133,7 @@ class TypeChecker:
                 'array_type.index': [Token('elem', TokenType.ARRAY_ELEMENT)],
                 'array_type.pop': [],
                 'array_type.prepend': [Token('elem', TokenType.ARRAY_ELEMENT)],
+                'array_type.prextend': [Token('gen_arr', TokenType.GEN_ARRAY)],
             }
         )
 

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -714,6 +714,8 @@ class TypeChecker:
             actual_types.append(actual)
             if expected.token == TokenType.ARRAY_ELEMENT:
                 matches.append(self.is_element_of_expected(actual, self_type if self_type.exists() else expected.token, arg))
+            elif expected.token == TokenType.GEN_ARRAY:
+                matches.append(self.is_similar_type(actual.flat_string(), self_type.flat_string() if self_type.exists() else expected.flat_string(), arg))
             else:
                 matches.append(self.is_similar_type(actual.flat_string(), expected.flat_string(), arg, is_call=True))
 

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -64,6 +64,12 @@ class TypeChecker:
             'array_type.reverse',
             'array_type.append',
             'array_type.has',
+            'array_type.clear',
+            'array_type.count',
+            'array_type.extend',
+            'array_type.index',
+            'array_type.pop',
+            'array_type.prepend',
         }
         self.class_signatures.update(
             {
@@ -88,6 +94,12 @@ class TypeChecker:
                 'array_type.reverse': (Declaration(), Token('san', TokenType.SAN), GlobalType.CLASS_METHOD),
                 'array_type.has': (Declaration(), Token('sama', TokenType.SAMA), GlobalType.CLASS_METHOD),
                 'array_type.append': (Declaration(), Token('san', TokenType.SAN), GlobalType.CLASS_METHOD),
+                'array_type.clear': (Declaration(), Token('san', TokenType.SAN), GlobalType.CLASS_METHOD),
+                'array_type.count': (Declaration(), Token('chan', TokenType.CHAN), GlobalType.CLASS_METHOD),
+                'array_type.extend': (Declaration(), Token('san', TokenType.SAN), GlobalType.CLASS_METHOD),
+                'array_type.index': (Declaration(), Token('chan', TokenType.CHAN), GlobalType.CLASS_METHOD),
+                'array_type.pop': (Declaration(), Token('san', TokenType.SAN), GlobalType.CLASS_METHOD),
+                'array_type.prepend': (Declaration(), Token('san', TokenType.SAN), GlobalType.CLASS_METHOD),
             },
         )
         self.class_method_param_types.update(
@@ -113,6 +125,12 @@ class TypeChecker:
                 'array_type.reverse': [],
                 'array_type.append': [Token('elem', TokenType.ARRAY_ELEMENT)],
                 'array_type.has': [Token('elem', TokenType.ARRAY_ELEMENT)],
+                'array_type.clear': [],
+                'array_type.count': [Token('elem', TokenType.ARRAY_ELEMENT)],
+                'array_type.extend': [Token('gen_arr', TokenType.GEN_ARRAY)],
+                'array_type.index': [Token('elem', TokenType.ARRAY_ELEMENT)],
+                'array_type.pop': [],
+                'array_type.prepend': [Token('elem', TokenType.ARRAY_ELEMENT)],
             }
         )
 

--- a/src/builtin/types/types.py
+++ b/src/builtin/types/types.py
@@ -165,9 +165,11 @@ class Array:
         return self.val.index(item)
     def _pop(self) -> None:
         if len(self.val) == 0: return
-        self.val.pop()
+        _ = self.val.pop()
     def _prepend(self, item) -> None:
         self.val.insert(0, item)
+    def _prextend(self, item) -> None:
+        self.val = item + self.val
 
     ## UTILS
     def valid_array_elems(self) -> list[type]:

--- a/src/builtin/types/types.py
+++ b/src/builtin/types/types.py
@@ -154,6 +154,20 @@ class Array:
         self.val.append(item)
     def _has(self, item) -> bool:
         return item in self.val
+    def _clear(self) -> None:
+        self.val.clear()
+    def _count(self, item) -> int:
+        return self.val.count(item)
+    def _extend(self, item) -> None:
+        self.val.extend(item)
+    def _index(self, item) -> int:
+        if item not in self.val: return -1
+        return self.val.index(item)
+    def _pop(self) -> None:
+        if len(self.val) == 0: return
+        self.val.pop()
+    def _prepend(self, item) -> None:
+        self.val.insert(0, item)
 
     ## UTILS
     def valid_array_elems(self) -> list[type]:

--- a/src/lexer/token.py
+++ b/src/lexer/token.py
@@ -188,6 +188,8 @@ class TokenType(Enum):
 
     # for `append()` type checking
     ARRAY_ELEMENT = ("elem", "all")
+    # for `extend()` type checking
+    GEN_ARRAY = ("gen_arr", "all")
 
 class UniqueTokenType:
     """


### PR DESCRIPTION
closes #207 

---

### new
1. all of methods mentioned in #207 
> _no descriptions means the same as python's behavior_
> - [x] `prepend()` prepends items to start of the array
>   - uses `insert(0)` under the hood
> - [x] `pop()` removes the last element in the list ALWAYS and does not return anything
> - [x] `index()` works the same but instead of raising when cannot find the value, it will return `-1`
> - [x]  `extend()`
> - [x] `prextend()` like extend but at the beginning of the list
> - [x] `clear()`
> - [x] `count()`

---

 test log
```
sample text file
---------------------------------------------------------
 1 |
 2 |     fwunc mainuwu-san() [[
 3 |         a-senpai[] = {}~
 4 |         a.prepend("1")~
 5 |         a.append("2")~
 6 |         a.prepend({"0"})~
 7 |         a.append({"3"})~
 8 |         a.extend({"4"})~
 9 |         a.extend({"4", "5"})~
10 |         a.extend({})~
11 |         a.pop()~
12 |         b-chan = a.index({"4"})~
13 |         a.clear()~
14 |         a.prextend({"1", {"2"}, "3", {{"4"}, "5"}})~
15 |     ]]
16 |
---------------------------------------------------------
end of file

def main():
    _a: Array = Array([])
    _a._prepend(String("1"))
    _a._append(String("2"))
    _a._prepend(Array([String("0")]))
    _a._append(Array([String("3")]))
    _a._extend(Array([String("4")]))
    _a._extend(Array([String("4"), String("5")]))
    _a._extend(Array([]))
    _a._pop()
    _b: int = int(float(_a._index(Array([String("4")]))))
    _a._clear()
    _a._prextend(Array([String("1"), Array([String("2")]), String("3"), Array([Array([String("4")]), String("5")])]))

if __name__ == '__main__':
    # clear screen before executing
    import platform
    import os
    os.system('cls' if platform.system() == 'Windows' else 'clear')

    # declare globals
    main()
```
