### PR TITLE
Feat/semantic error context

### DIFF
--- a/src/analyzer/error_handler.py
+++ b/src/analyzer/error_handler.py
@@ -25,7 +25,7 @@ class SemanticError:
     @abstractmethod
     def __str__(self) -> str: ...
     @abstractmethod
-    def position(self) -> tuple[int, int]: ...
+    def position(self) -> tuple[int, int]|None: ...
     @abstractmethod
     def string(self) -> str: ...
 
@@ -35,6 +35,9 @@ class DuplicateDefinitionError(SemanticError):
         self.duplicate = duplicate
         self.original_type = original_type
         self.duplicate_type = duplicate_type
+
+    def position(self) -> tuple[int, int]|None:
+        return self.duplicate.position
 
     def __str__(self):
         index_str = str(self.original.position[0] + 1)
@@ -71,6 +74,9 @@ class NonFunctionIdCall(SemanticError):
         self.original = original
         self.called = called
 
+    def position(self) -> tuple[int, int]|None:
+        return self.called.position
+
     def __str__(self):
         index_str = str(self.original.position[0] + 1)
         dupe_index = str(self.called.position[0] + 1)
@@ -105,6 +111,9 @@ class FunctionAssignmentError(SemanticError):
         self.original = original
         self.assignment = assignment
         self.class_signature = class_signature
+
+    def position(self) -> tuple[int, int]|None:
+        return self.assignment.position
 
     def __str__(self):
         index_str = str(self.original.position[0] + 1) if self.original else ""
@@ -148,6 +157,9 @@ class UndefinedError(SemanticError):
         self.token = token
         self.gtype = gtype
 
+    def position(self) -> tuple[int, int]|None:
+        return self.token.position
+
     def __str__(self):
         index_str = str(self.token.position[0] + 1)
         max_pad = len(index_str)
@@ -173,6 +185,9 @@ class ReassignedConstantError:
         self.defined_token = defined_token
         self.header = header
         self.msg = token_msg
+
+    def position(self) -> tuple[int, int]|None:
+        return self.token.position
 
     def __str__(self):
         index_str = str(self.token.position[0] + 1)
@@ -212,6 +227,9 @@ class ReturnTypeMismatchError(SemanticError):
         self.expected = expected
         self.return_stmt = return_stmt
         self.actual_type = actual_type
+
+    def position(self) -> tuple[int, int]|None:
+        return self.expected.position
 
     def __str__(self):
         expected_index = str(self.expected.position[0] + 1)
@@ -254,6 +272,9 @@ class TypeMismatchError(SemanticError):
         self.context = context
         self.title = title # if None, its a declaration, if true, its an assignment
 
+    def position(self) -> tuple[int, int]|None:
+        return extract_id(self.context.id).position
+
     def __str__(self):
         index_str = str(self.expected.position[0] + 1)
         assign_index_str = (str(extract_id(self.context.id).position[0] + 1) + '..n') if self.title else 'rhs'
@@ -293,6 +314,9 @@ class PrePostFixOperandError(SemanticError):
         self.val_type = val_type
         self.header = header
         self.postfix = postfix
+
+    def position(self) -> tuple[int, int]|None:
+        return None
 
     def __str__(self):
         op_index = str(self.op.position[0] + 1)
@@ -337,6 +361,9 @@ class InfixOperandError(SemanticError):
         self.left_type = left_type
         self.right_type = right_type
         self.header = header
+
+    def position(self) -> tuple[int, int]|None:
+        return None
 
     def __str__(self):
         op_str = str(self.op.position[0] + 1)
@@ -412,6 +439,9 @@ class NonIterableIndexingError(SemanticError):
         self.token_type = token_type
         self.usage = usage
 
+    def position(self) -> tuple[int, int]|None:
+        return self.token.position
+
     def __str__(self):
         tok_index = str(self.token.position[0] + 1)
         def_index = str(self.type_definition.position[0] + 1)
@@ -449,6 +479,9 @@ class NonClassAccessError(SemanticError):
         self.id_definition = id_definition
         self.usage = usage
         self.initialized = initialized
+
+    def position(self) -> tuple[int, int]|None:
+        return self.id.position
 
     def __str__(self):
         id_index = str(self.id.position[0] + 1)
@@ -499,6 +532,9 @@ class UndefinedClassMember(SemanticError):
         self.member_type = member_type
         self.actual_definition, self.actual_type = actual_definition
 
+    def position(self) -> tuple[int, int]|None:
+        return self.property.position
+
     def __str__(self):
         property_index = str(self.property.position[0] + 1)
         max_pad = len(property_index)
@@ -541,6 +577,9 @@ class MismatchedCallArgType(SemanticError):
         self.args = args
         self.actual_types = actual_types
         self.matches = matches
+
+    def position(self) -> tuple[int, int]|None:
+        return self.id.position
 
     def __str__(self):
         id_index = str(self.id.position[0] + 1)
@@ -630,6 +669,9 @@ class HeterogeneousArrayError(SemanticError):
         self.vals = vals
         self.types = types
 
+    def position(self) -> tuple[int, int] | None:
+        return None
+
     def __str__(self):
         max_pad = 3
         max_len = len(self.arr.flat_string())
@@ -671,6 +713,9 @@ class NoReturnStatement(SemanticError):
     def __init__(self, func: Function, cwass:str|None=None):
         self.func = func
         self.cwass = cwass
+
+    def position(self) -> tuple[int, int] | None:
+        return self.func.id.position
 
     def __str__(self):
         last_stmt = final_statement(self.func.body) + 1

--- a/src/analyzer/error_handler.py
+++ b/src/analyzer/error_handler.py
@@ -20,7 +20,16 @@ class GlobalType(Enum):
 class ErrorSrc:
     src = [""]
 
-class DuplicateDefinitionError:
+# base abstract class for all error types
+class SemanticError:
+    @abstractmethod
+    def __str__(self) -> str: ...
+    @abstractmethod
+    def position(self) -> tuple[int, int]: ...
+    @abstractmethod
+    def string(self) -> str: ...
+
+class DuplicateDefinitionError(SemanticError):
     def __init__(self, original: Token, original_type: GlobalType, duplicate: Token, duplicate_type: GlobalType):
         self.original = original
         self.duplicate = duplicate
@@ -57,7 +66,7 @@ class DuplicateDefinitionError:
 
         return msg
 
-class NonFunctionIdCall:
+class NonFunctionIdCall(SemanticError):
     def __init__(self, original: Token, called: Token):
         self.original = original
         self.called = called
@@ -91,7 +100,7 @@ class NonFunctionIdCall:
         msg += border
         return msg
 
-class FunctionAssignmentError:
+class FunctionAssignmentError(SemanticError):
     def __init__(self, original: Token|None, assignment: Token, class_signature: str|None = None):
         self.original = original
         self.assignment = assignment
@@ -134,7 +143,7 @@ class FunctionAssignmentError:
         msg += border
         return msg
 
-class UndefinedError:
+class UndefinedError(SemanticError):
     def __init__(self, token: Token, gtype: GlobalType) -> None:
         self.token = token
         self.gtype = gtype
@@ -198,7 +207,7 @@ class ReassignedConstantError:
 
         return msg
 
-class ReturnTypeMismatchError:
+class ReturnTypeMismatchError(SemanticError):
     def __init__(self, expected: Token, return_stmt: ReturnStatement, actual_type: TokenType) -> None:
         self.expected = expected
         self.return_stmt = return_stmt
@@ -236,7 +245,7 @@ class ReturnTypeMismatchError:
         msg += border
         return msg
 
-class TypeMismatchError:
+class TypeMismatchError(SemanticError):
     def __init__(self, expected: Token, actual_val: Value, actual_type: TokenType,
                  context: Assignment|Declaration, title: str) -> None:
         self.expected = expected
@@ -276,7 +285,7 @@ class TypeMismatchError:
         msg += border
         return msg
 
-class PrePostFixOperandError:
+class PrePostFixOperandError(SemanticError):
     def __init__(self, op: Token, val: Value, val_definition: Token|None, val_type: TokenType, header: str, postfix=False) -> None:
         self.op = op
         self.val = val
@@ -317,7 +326,7 @@ class PrePostFixOperandError:
         msg += border
         return msg
 
-class InfixOperandError:
+class InfixOperandError(SemanticError):
     def __init__(self, op: Token, left: tuple[Value, Token|None], 
                  right: tuple[Value, Token|None],
                  left_type: TokenType|None, right_type: TokenType|None,
@@ -396,7 +405,7 @@ class InfixOperandError:
         msg += border + '\n'
         return msg
 
-class NonIterableIndexingError:
+class NonIterableIndexingError(SemanticError):
     def __init__(self, token: Token, type_definition: Token, token_type: TokenType, usage: str) -> None:
         self.token = token
         self.type_definition = type_definition
@@ -434,7 +443,7 @@ class NonIterableIndexingError:
         msg += border
         return msg
 
-class NonClassAccessError:
+class NonClassAccessError(SemanticError):
     def __init__(self, id: Token, id_definition: Token|None, usage: str, initialized=True) -> None:
         self.id = id
         self.id_definition = id_definition
@@ -482,7 +491,7 @@ class NonClassAccessError:
         msg += border
         return msg
 
-class UndefinedClassMember:
+class UndefinedClassMember(SemanticError):
     def __init__(self, cwass: str, property: Token, member_type: GlobalType,
                  actual_definition: tuple[Token|None, GlobalType|None]=(None, None)) -> None:
         self.cwass = cwass
@@ -520,7 +529,7 @@ class UndefinedClassMember:
         msg += border
         return msg
 
-class MismatchedCallArgType:
+class MismatchedCallArgType(SemanticError):
     def __init__(self, global_type: GlobalType, call_str: str, id: Token, id_definition: Token|None,
                  expected_types: list[str], args: list[Value], actual_types: list[TokenType], matches: list[bool]
                  ) -> None:
@@ -615,7 +624,7 @@ class MismatchedCallArgType:
         msg += border
         return msg
 
-class HeterogeneousArrayError:
+class HeterogeneousArrayError(SemanticError):
     def __init__(self, arr: ArrayLiteral, vals: list[Value], types: list[str]):
         self.arr = arr
         self.vals = vals
@@ -658,7 +667,7 @@ class HeterogeneousArrayError:
         msg += border
         return msg
 
-class NoReturnStatement:
+class NoReturnStatement(SemanticError):
     def __init__(self, func: Function, cwass:str|None=None):
         self.func = func
         self.cwass = cwass


### PR DESCRIPTION
closes #216 
closes #217 

---

### all semantic errors have `position()` and `string()` method
- `position()` returns an optional tuple of two ints of a token where the error occured
- `string()` is the unstyled error message for UI
