### PR TITLE
fix: disallow special literals as index in indexed id

### DIFF
--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -1153,7 +1153,9 @@ class Parser:
             tmp = IndexedIdentifier()
             tmp.id = ident
             ident = tmp
-            if (idx := self.parse_expression(LOWEST)) is None:
+            limit = self.expected_prefix.copy()
+            limit.remove(TokenType.DASH)
+            if (idx := self.parse_expression(LOWEST, limit_to=limit)) is None:
                 return None
             if not self.expect_peek(TokenType.CLOSE_BRACKET):
                 self.expected_error([TokenType.CLOSE_BRACKET, *self.error_context(idx)])


### PR DESCRIPTION
string literals, array literals, and nuww is no longer allowed as index in array indices

sample error msg
```
[UNEXPECTED TOKEN] Error on line 3 column 17:
        Expected next token to be one of the ff: '(', 'IDENTIFIER', 'INT_LITERAL', 'FLOAT_LITERAL', 'fax', 'cap'
        got '{' instead
        __________________________
        3 |         a.a = b[ {} ]~
          |                  ^
        __________________________
```