### PR TITLE
Refactor/indexing using braces

### DIFF
--- a/constants/constants.py
+++ b/constants/constants.py
@@ -37,7 +37,7 @@ DELIMS = {
     'close_brace': {'}', '~', ' ', ',', ')', '\n', '>', '&', *ATOMS['general_operator'], '!', '|'},
     'open_parenthesis': {'{', *ATOMS['number'], *ATOMS['alpha'], ' ', '-', '\n', '>', '(', ')', '"'},
     'id': {'{', '\n', ' ', '~', ',', '(', ')', '[', ']', '}', *ATOMS['general_operator'], '!', r'&', '|', '.'},
-    'close_parenthesis': {' ', *ATOMS['general_operator'], '!', '&', '|', '\n', '~', '>', '.', ',', ')', '(', '[', ']', '}'},
+    'close_parenthesis': {'{', ' ', *ATOMS['general_operator'], '!', '&', '|', '\n', '~', '>', '.', ',', ')', '(', '[', ']', '}'},
     'open_bracket': {']', *ATOMS['number'], '-', *ATOMS['alpha'], '(', ' ', '\n'},
     'double_open_bracket': {' ', '\n', *ATOMS['alpha'], '>'},
     'close_bracket': {'\n', '(', ' ', '~', ',', ')', '[', ']', '}', *ATOMS['general_operator'], '!', r'&', '|', '.', '\n'},

--- a/constants/constants.py
+++ b/constants/constants.py
@@ -34,7 +34,7 @@ DELIMS = {
     'logical_delim': {'"', *ATOMS['alpha'], *ATOMS['number'], ' ', '-', '(', '{', '\n'},
     'string_parts': {'"', *ATOMS['alpha'], *ATOMS['number'], ' ', '-', '(', '|', '\n', '&'},
     'open_brace': {'{', '}', '(', *ATOMS['number'], ' ', '"', *ATOMS['alpha'], '\n', '>', '-'},
-    'close_brace': {'}', '~', ' ', ',', ')', '\n', '>', '&', *ATOMS['general_operator'], '!', '|'},
+    'close_brace': {'{', '}', '~', ' ', ',', ')', '\n', '>', '&', *ATOMS['general_operator'], '!', '|'},
     'open_parenthesis': {'{', *ATOMS['number'], *ATOMS['alpha'], ' ', '-', '\n', '>', '(', ')', '"'},
     'id': {'{', '\n', ' ', '~', ',', '(', ')', '[', ']', '}', *ATOMS['general_operator'], '!', r'&', '|', '.'},
     'close_parenthesis': {'{', ' ', *ATOMS['general_operator'], '!', '&', '|', '\n', '~', '>', '.', ',', ')', '(', '[', ']', '}'},

--- a/constants/constants.py
+++ b/constants/constants.py
@@ -36,7 +36,7 @@ DELIMS = {
     'open_brace': {'{', '}', '(', *ATOMS['number'], ' ', '"', *ATOMS['alpha'], '\n', '>', '-'},
     'close_brace': {'}', '~', ' ', ',', ')', '\n', '>', '&', *ATOMS['general_operator'], '!', '|'},
     'open_parenthesis': {'{', *ATOMS['number'], *ATOMS['alpha'], ' ', '-', '\n', '>', '(', ')', '"'},
-    'id': {'\n', ' ', '~', ',', '(', ')', '[', ']', '}', *ATOMS['general_operator'], '!', r'&', '|', '.'},
+    'id': {'{', '\n', ' ', '~', ',', '(', ')', '[', ']', '}', *ATOMS['general_operator'], '!', r'&', '|', '.'},
     'close_parenthesis': {' ', *ATOMS['general_operator'], '!', '&', '|', '\n', '~', '>', '.', ',', ')', '(', '[', ']', '}'},
     'open_bracket': {']', *ATOMS['number'], '-', *ATOMS['alpha'], '(', ' ', '\n'},
     'double_open_bracket': {' ', '\n', *ATOMS['alpha'], '>'},

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -295,7 +295,7 @@ class Parser:
         # -dono to indicate constant
         if self.expect_peek(TokenType.DASH):
             if for_loop_init:
-                expecteds = [TokenType.ASSIGNMENT_OPERATOR] + ([TokenType.OPEN_BRACKET] if not d.dtype.is_arr_type() else [])
+                expecteds = [TokenType.ASSIGNMENT_OPERATOR] + ([TokenType.OPEN_BRACE] if not d.dtype.is_arr_type() else [])
                 self.expected_error(expecteds, curr=True)
                 self.advance()
                 return None
@@ -310,7 +310,7 @@ class Parser:
         d.initialized = False
         if not self.expect_peek(TokenType.ASSIGNMENT_OPERATOR):
             if for_loop_init:
-                expecteds = [TokenType.ASSIGNMENT_OPERATOR] + ([TokenType.OPEN_BRACKET] if not d.dtype.is_arr_type() else [])
+                expecteds = [TokenType.ASSIGNMENT_OPERATOR] + ([TokenType.OPEN_BRACE] if not d.dtype.is_arr_type() else [])
                 self.expected_error(expecteds)
                 self.advance(2)
                 return None
@@ -319,7 +319,7 @@ class Parser:
                     expecteds =[TokenType.TERMINATOR, TokenType.ASSIGNMENT_OPERATOR] 
                     if not d.dono_token.exists():
                         if not d.dtype.is_arr_type():
-                            expecteds.append(TokenType.OPEN_BRACKET)
+                            expecteds.append(TokenType.OPEN_BRACE)
                         expecteds.append(TokenType.DASH)
                     self.expected_error(expecteds)
                     self.advance(2)
@@ -1101,7 +1101,7 @@ class Parser:
         ident = self.curr_tok
         is_call = False
 
-        if not self.peek_tok_is_in([TokenType.OPEN_PAREN, TokenType.DOT_OP, TokenType.OPEN_BRACKET]):
+        if not self.peek_tok_is_in([TokenType.OPEN_PAREN, TokenType.DOT_OP, TokenType.OPEN_BRACE]):
             return ident
 
         if self.peek_tok_is(TokenType.OPEN_PAREN):
@@ -1143,7 +1143,7 @@ class Parser:
                 return None
 
         # array indexing, keep looping until curr tok is not close bracket
-        if self.peek_tok_is(TokenType.OPEN_BRACKET):
+        if self.peek_tok_is(TokenType.OPEN_BRACE):
             if not expr and is_call:
                 self.peek_error(TokenType.TERMINATOR)
                 self.advance(2)
@@ -1157,18 +1157,18 @@ class Parser:
             limit.remove(TokenType.DASH)
             if (idx := self.parse_expression(LOWEST, limit_to=limit)) is None:
                 return None
-            if not self.expect_peek(TokenType.CLOSE_BRACKET):
-                self.expected_error([TokenType.CLOSE_BRACKET, *self.error_context(idx)])
+            if not self.expect_peek(TokenType.CLOSE_BRACE):
+                self.expected_error([TokenType.CLOSE_BRACE, *self.error_context(idx)])
                 return None
 
             ident.index.append(idx)
             # if more indexing exists
-            while self.expect_peek(TokenType.OPEN_BRACKET):
+            while self.expect_peek(TokenType.OPEN_BRACE):
                 self.advance()
                 if (idx := self.parse_expression(LOWEST)) is None:
                     return None
-                if not self.expect_peek(TokenType.CLOSE_BRACKET):
-                    self.expected_error([TokenType.CLOSE_BRACKET, *self.error_context(idx)])
+                if not self.expect_peek(TokenType.CLOSE_BRACE):
+                    self.expected_error([TokenType.CLOSE_BRACE, *self.error_context(idx)])
                     return None
                 ident.index.append(idx)
 

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -234,7 +234,7 @@ class IndexedIdentifier(IdentifierProds):
     def flat_string(self) -> str:
         res = self.id.flat_string()
         for index in self.index:
-            res += f"[{index.flat_string()}]"
+            res += f"{{{index.flat_string()}}}"
         return res
     def python_string(self, indent=0, cwass=False) -> str:
         res = self.id.python_string(cwass=cwass)


### PR DESCRIPTION
### main change
- id indexing now uses braces instead of brackets

### etc
- add `{` as delimiter for identifiers, close parenthesis, and closing brace
- debug output in console show indexing using braces
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/809b8a72-82e3-4ab3-a58d-09950e5ed509)

---
error using brackets to index
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/bae3adf9-357a-4580-bbb8-5b3d1c696d97)
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/ec9fed00-b69e-4ab2-a6b0-63c7619e12c7)
