### PR TITLE
Feat/remove breaks outside loops

### DIFF
--- a/src/analyzer/analyzer.py
+++ b/src/analyzer/analyzer.py
@@ -121,6 +121,8 @@ class MemberAnalyzer:
                     self.analyze_return(stmt, local_defs)
                 case IdentifierProds():
                     self.analyze_ident_prods(stmt, local_defs)
+                case Break():
+                    pass
                 case _:
                     raise ValueError(f"Unknown statement: {stmt}")
 

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -188,6 +188,8 @@ class TypeChecker:
                     self.evaluate_fn_call(statement, local_defs)
                 case ClassAccessor():
                     self.check_and_evaluate_class_accessor(statement, local_defs)
+                case Break():
+                    pass
                 case _:
                     raise ValueError(f"Unknown statement: {statement}")
 

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -202,6 +202,7 @@ class Parser:
         self.register_in_block(TokenType.DO_WHIWE, self.parse_while_statement)
         self.register_in_block(TokenType.FOW, self.parse_for_statement)
         self.register_in_block(TokenType.PWINT, self.parse_print)
+        self.register_in_block(TokenType.BWEAK, self.parse_break)
         # TODO: change cfg to accomodate this as an in block statement
         # self.register_in_block(TokenType.INPWT, self.parse_input)
 
@@ -1363,6 +1364,16 @@ class Parser:
     def parse_literal(self) -> Token:
         'returns the current token'
         return self.curr_tok
+
+    def parse_break(self) -> Break|None:
+        'must start with break in current token'
+        b = Break()
+        b.token = self.curr_tok
+        if not self.expect_peek(TokenType.TERMINATOR):
+            self.peek_error(TokenType.TERMINATOR)
+            self.advance(2)
+            return None
+        return b
 
     ### helper methods
     # registering prefix and infix functions to parse certain token types

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -1,3 +1,4 @@
+import re
 from src.lexer.token import TokenType, UniqueTokenType, class_properties
 from src.parser.production_types import *
 from src.lexer import Token
@@ -625,6 +626,8 @@ class WhileLoop(Statement):
         res = ""
         if self.is_do:
             res = self.body.python_string(indent, cwass=cwass)
+            # initial body of do while, remove breaks
+            res = re.sub(r"break", "...", res)
         res += sprintln(f"while {self.condition.python_string(cwass=cwass)}:", indent=indent)
         res += self.body.python_string(indent+1, cwass=cwass)
         return res

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -680,6 +680,21 @@ class ForLoop(Statement):
 
         return sprint(res, indent=indent)
 
+class Break(Statement):
+    def __init__(self):
+        self.token: Token = Token()
+
+    def header(self):
+        return "break statement:"
+    def child_nodes(self) -> None | dict[str, Production | Token]:
+        return {"break":self.token}
+
+    def string(self, indent = 0) -> str:
+        return sprintln("break statement:", self.id.flat_string(), indent=indent)
+    def python_string(self, indent=0, cwass=False) -> str:
+        return sprintln("break", indent=indent)
+    def formatted_string(self, indent=0) -> str:
+        return sprintln("bweak~", indent=indent)
 
 class Function(Production):
     def __init__(self):

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -683,6 +683,7 @@ class ForLoop(Statement):
 class Break(Statement):
     def __init__(self):
         self.token: Token = Token()
+        self.in_loop: bool = False
 
     def header(self):
         return "break statement:"
@@ -692,7 +693,7 @@ class Break(Statement):
     def string(self, indent = 0) -> str:
         return sprintln("break statement:", self.id.flat_string(), indent=indent)
     def python_string(self, indent=0, cwass=False) -> str:
-        return sprintln("break", indent=indent)
+        return sprint("break" if self.in_loop else "...", indent=indent)
     def formatted_string(self, indent=0) -> str:
         return sprintln("bweak~", indent=indent)
 


### PR DESCRIPTION
closes #237 

---
### continued from previous pr #235 (Feat/break statement everything)
> whoops forgot to even do break statements
> 
> ### new
> - parsing break statements
> - member check and type check does not break when encountering `bweak` statement
---
# all breaks are transpiled to `...` if not inside a loop

### test log
```
def main():
    ...
    if True:
        ...
        while True:
            break
            while True:
                break

            break

        ...
    elif True:
        ...
        _i: int = int(float(0))
        while True:
            break
            while True:
                break

            break
            _i = True

        ...
    elif True:
        ...
        while True:
            break

        ...
    else:
        ...
        ...
        while True:
            break

        ...

    ...

if __name__ == '__main__':
    # clear screen before executing
    import platform
    import os
    os.system('cls' if platform.system() == 'Windows' else 'clear')

    # declare globals
    main()
```