### PR TITLE
Fix/wrong error message using fn as value

### DIFF
--- a/src/analyzer/analyzer.py
+++ b/src/analyzer/analyzer.py
@@ -1,5 +1,5 @@
 from src.lexer.token import TokenType, UniqueTokenType
-from src.analyzer.error_handler import DuplicateDefinitionError, FunctionAssignmentError, GlobalType, NonFunctionIdCall, UndefinedError
+from src.analyzer.error_handler import DuplicateDefinitionError, FnUsedAsVar, FunctionAssignmentError, GlobalType, NonFunctionIdCall, UndefinedError
 from src.parser.productions import *
 
 class MemberAnalyzer:
@@ -350,7 +350,7 @@ class MemberAnalyzer:
                 if token.string() in local_defs:
                     if not local_defs[token.string()][1] in (
                         GlobalType.IDENTIFIER, GlobalType.CLASS_PROPERTY, GlobalType.LOCAL_CLASS_ID, GlobalType.CLASS):
-                        self.errors.append(FunctionAssignmentError(
+                        self.errors.append(FnUsedAsVar(
                             local_defs[token.string()][0],
                             token,
                         ))

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -341,10 +341,10 @@ class TypeChecker:
     def check_assignment(self, assign: Assignment, local_defs: dict[str, tuple[Declaration, Token, GlobalType]]) -> None:
         signature, token, decl, dono_token, global_type = self.extract_last_id(assign.id, local_defs)
         try:
-            original_def = local_defs[signature][0]
+            original_def, expected_type = local_defs[signature][:2]
         except KeyError:
-            original_def = self.class_signatures[signature][0]
-            if signature in self.builtin_signatures:
+            original_def, expected_type = self.class_signatures[signature][:2]
+            if signature in self.builtin_signatures or not original_def.id.exists():
                 original_def = None
         if decl.dono_token.exists():
             signature = self.extract_id(assign.id)
@@ -365,7 +365,7 @@ class TypeChecker:
                     class_signature=signature,
                 )
             )
-        self.check_value(assign.value, decl.dtype, local_defs, assignment=True, decl=decl, assign=assign)
+        self.check_value(assign.value, expected_type, local_defs, assignment=True, decl=decl, assign=assign)
 
     def check_value(self, value: Value, expected_type: Token, local_defs: dict[str, tuple[Declaration, Token, GlobalType]],
                     assignment: bool = False, decl: Declaration = Declaration(), assign: Assignment = Assignment()) -> None:

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -1032,18 +1032,18 @@ class TypeChecker:
                 while isinstance(val_tmp, ClassAccessor):
                     match val_tmp.accessed:
                         case Token():
-                            accessed = f"{class_type.id.flat_string()}.{val_tmp.accessed.flat_string()}"
+                            accessed = f"{class_type.dtype.flat_string()}.{val_tmp.accessed.flat_string()}"
                             return accessed, val_tmp.accessed, *self.class_signatures[accessed]
                         case FnCall():
-                            accessed =f"{class_type.id.flat_string()}.{val_tmp.accessed.id.flat_string()}" 
+                            accessed =f"{class_type.dtype.flat_string()}.{val_tmp.accessed.id.flat_string()}" 
                             return accessed, val_tmp.accessed.id, *self.class_signatures[accessed]
                         case IndexedIdentifier():
                             match val_tmp.accessed.id:
                                 case Token():
-                                    accessed = f"{class_type.id.flat_string()}.{val_tmp.accessed.id.flat_string()}"
+                                    accessed = f"{class_type.dtype.flat_string()}.{val_tmp.accessed.id.flat_string()}"
                                     return accessed, val_tmp.accessed.id, *self.class_signatures[accessed]
                                 case FnCall():
-                                    accessed = f"{class_type.id.flat_string()}.{val_tmp.accessed.id.id.flat_string()}"
+                                    accessed = f"{class_type.dtype.flat_string()}.{val_tmp.accessed.id.id.flat_string()}"
                                     return accessed, val_tmp.accessed.id.id, *self.class_signatures[accessed]
                                 case _:
                                     raise ValueError(f"Unknown class accessor: {val}")


### PR DESCRIPTION
## change
- differentiate when trying to assign value to a function and using function id as value without calling it

## etc
- bugfix: using id instead of dtype when type checking assignments and class accessors

---

### src
```python
sample text file
---------------------------
1 |
2 | fwunc mainuwu-san() [[
3 |     a-chan =  b + 1~
4 |     b = 1~
5 | ]]
6 | fwunc b-chan(c-chan) [[
7 |     wetuwn(0)~
8 | ]]
9 |
---------------------------
end of file
```

### before
```python
Tried to assign a value to a function: b()
        ____________________________
          |     Original function definition
        6 | fwunc b-chan(c-chan) [[
          |       ^
          | ______|
          | |
          | |   'b()' is a function and cannot be assigned to
        3 | |    a-chan =  b + 1~
          | |              ^
          | |______________|
        ____________________________

Tried to assign a value to a function: b()
        ____________________________
          |     Original function definition
        6 | fwunc b-chan(c-chan) [[
          |       ^
          | ______|
          | |
          | |   'b()' is a function and cannot be assigned to
        4 | |    b = 1~
          | |    ^
          | |____|
        ____________________________
```
### after
```python
Tried to use function as value: b()
        ____________________________
          |     Original function definition
        6 | fwunc b-chan(c-chan) [[
          |       ^
          | ______|
          | |
          | |   'b()' is a function and cannot be used as a value without calling it
        3 | |    a-chan =  b + 1~
          | |              ^
          | |______________|
        ____________________________

Tried to assign a value to a function: b()
        ____________________________
          |     Original function definition
        6 | fwunc b-chan(c-chan) [[
          |       ^
          | ______|
          | |
          | |   'b()' is a function and cannot be assigned to
        4 | |    b = 1~
          | |    ^
          | |____|
        ____________________________
```