### PR TITLE
add tilde when fncall is a statement

### DIFF
--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -740,6 +740,10 @@ class Parser:
                     peek_accessed = last_accessed.id
         if isinstance(last_accessed, FnCall):
             assert isinstance(res, FnCall) or isinstance(res, ClassAccessor)
+            if isinstance(res, FnCall):
+                res.is_statement = True
+            elif isinstance(res, ClassAccessor):
+                res.accessed.is_statement = True
             if not self.expect_peek(TokenType.TERMINATOR):
                 self.peek_error(TokenType.TERMINATOR)
                 self.advance(2)

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -256,6 +256,8 @@ class FnCall(IdentifierProds):
         self.id: Token = Token()
         self.args: list[Value] = []
 
+        self.is_statement = False
+
     def header(self):
         return sprint("call:", self.id.string(),indent=0)
     def child_nodes(self) -> None | dict[str, Production | Token]:
@@ -268,7 +270,8 @@ class FnCall(IdentifierProds):
     def python_string(self, indent=0, cwass=False) -> str:
         return sprint(f"{self.id.python_string(cwass=cwass)}({', '.join(a.python_string(cwass=cwass) for a in self.args)})", indent=indent)
     def formatted_string(self, indent=0) -> str:
-        return sprint(f"{self.id.formatted_string()}({', '.join(a.formatted_string() for a in self.args)})", indent=indent)
+        tilde  = "~" if self.is_statement else ""
+        return sprint(f"{self.id.formatted_string()}({', '.join(a.formatted_string() for a in self.args)}){tilde}", indent=indent)
 
     def __len__(self):
         return 1


### PR DESCRIPTION
Fixes #251 

### Problem
- autoformat can't distinguish whether a function or method call was used as an expression or as a statement

### Fix
- new is_statement bool in FnCall that adds a terminator to the formatted string if True

### Preview
- Before Format
![image](https://github.com/Gidsss/UwUIDE/assets/66175571/9b0797fd-3051-4d1f-8c6d-188ee79e6dd5)
- After Format
![image](https://github.com/Gidsss/UwUIDE/assets/66175571/0794294e-ee3a-4a82-b62e-422b5a667ad6)
