### PR TITLE
Parsing and Formatting Comments

### DIFF
--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -98,8 +98,6 @@ class Parser:
 
         # to keep track of tokens
         self.pos = 0
-        self.curr_tok = self.tokens[self.pos]
-        self.peek_tok = self.tokens[self.pos + 1]
 
         # to keep track of whether inside loops
         self.loop_level = 0
@@ -107,6 +105,14 @@ class Parser:
         eof_pos = (self.tokens[-1].end_position[0], self.tokens[-1].end_position[1] + 1)
         self.tokens.append(Token("EOF", TokenType.EOF, eof_pos, eof_pos))
         self.program = self.parse_program()
+
+    @property
+    def curr_tok(self):
+        return self.tokens[self.pos]
+
+    @property
+    def peek_tok(self):
+        return self.tokens[self.pos + 1]
 
     def advance(self, inc: int = 1):
         'advance the current and peek tokens based on the increment. default is 1'
@@ -117,13 +123,10 @@ class Parser:
                 return
 
             if self.peek_tok.token == TokenType.EOF:
-                self.curr_tok = self.peek_tok
                 self.pos += 1
                 return
 
             self.pos += 1
-            self.curr_tok = self.peek_tok
-            self.peek_tok = self.tokens[self.pos + 1]
 
     def register_init(self):
         '''

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -112,9 +112,13 @@ class Parser:
 
     @property
     def peek_tok(self):
-        return self.tokens[self.pos + 1]
+        # Skip comments
+        pos = self.pos
+        while self.is_comment(self.tokens[pos+1]):
+            pos += 1
+        return self.tokens[pos + 1]
 
-    def advance(self, inc: int = 1):
+    def advance(self, inc: int = 1, skip_comments=True):
         'advance the current and peek tokens based on the increment. default is 1'
         if inc <= 0 :
             return
@@ -122,6 +126,9 @@ class Parser:
             if self.curr_tok.token == TokenType.EOF:
                 return
 
+            # Skip comments
+            while skip_comments and self.is_comment(self.tokens[self.pos+1]):
+                self.pos += 1
             if self.peek_tok.token == TokenType.EOF:
                 self.pos += 1
                 return
@@ -966,6 +973,9 @@ class Parser:
             self.advance()
             return None
         return p
+
+    def is_comment(self, token: Token):
+        return token.token in [TokenType.SINGLE_LINE_COMMENT, TokenType.MULTI_LINE_COMMENT]
 
     def parse_comment(self) -> Comment | None:
         return Comment(self.curr_tok)


### PR DESCRIPTION
### Features
- This PR adds proper comment parsing.
- It's able to parse comments outside of statements and blocks like before
- Now also able to ignore comments _inside_ most productions:
- Parses comments before and after globals, functions, classes, other comments, and statements inside blocks

### Changes
- Refactored curr_tok and peek_tok into class properties
- Added true_peek_tok, which should be used when you don't want to skip over comments during peeking (this is implemented the same way as our previous peek_tok)
- Added new optional parameters to some methods that specify whether or not to skip over comments (These are used in the comment parsing scenarios above)

### Preview
Source Code
- 
![image](https://github.com/Gidsss/UwUIDE/assets/66175571/eeb60c99-e37b-42ec-9f34-f2741921d0f1)
Formatted
- 
![image](https://github.com/Gidsss/UwUIDE/assets/66175571/50313c51-fdfc-4b82-9666-ce41a52ff8e5)
