### PR TITLE
fix: convert to int instead of Int in indexed identifiers

### DIFF
--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -299,7 +299,7 @@ class IndexedIdentifier(IdentifierProds):
     def python_string(self, indent=0, cwass=False) -> str:
         res = self.id.python_string(cwass=cwass)
         for index in self.index:
-            res += f"[{TokenType.CHAN.python_string()}({index.python_string(cwass=cwass)})]"
+            res += f"[int({index.python_string(cwass=cwass)})]"
         return res
     def formatted_string(self, indent=0) -> str:
         res = self.id.formatted_string()


### PR DESCRIPTION
closes #260 

---

# indices in subscripting is always converted to `int`, not `Int`
---

### source
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/d4f2a438-fae6-4392-9e9c-bdcfc6f8572a)

### transpiled
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/428cd2e1-fb04-4152-8123-bd61fdca25c5)

### output
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/ccef00c3-f989-4e59-93ae-ef7cacd9cd0a)
