### PR TITLE
Fix forward slash getting multiplied when formatting

### DIFF
--- a/src/lexer/token.py
+++ b/src/lexer/token.py
@@ -407,6 +407,8 @@ class Token:
                 return self.lexeme
 
     def formatted_string(self, indent=0) -> str:
+        if self.token == TokenType.STRING_LITERAL:
+            return self.lexeme.replace("\\\\", "\\")
         return self.lexeme
 
     def header(self):

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -199,7 +199,7 @@ class StringFmt(Iterable):
         res = f"{start}{''.join([c if type(c) == str else c.formatted_string() for c in self.mid_expr_uwu()])}{end}"
         if self.concats:
             res += ' & ' + ' & '.join(c.formatted_string() for c in self.concats)
-        return res
+        return res.replace("\\\\", "\\")
 
     def mid_expr_iter(self):
         if self.exprs:


### PR DESCRIPTION
## String Literals

Before
![image](https://github.com/Gidsss/UwUIDE/assets/66175571/f762dec2-94d5-4f57-9683-92d2ffe99f9a)

After
![image](https://github.com/Gidsss/UwUIDE/assets/66175571/96f30c30-bba3-4df8-ac0b-81db4965d275)

## Formatted Strings
Before
![image](https://github.com/Gidsss/UwUIDE/assets/66175571/115be00d-0a45-47e9-aabb-75fb4966086a)

After
![image](https://github.com/Gidsss/UwUIDE/assets/66175571/98b3b919-96f1-46e9-bda7-5ec82e6ae4df)

