### PR TITLE
fix: double backslash on escaped chars during compilation

### DIFF
--- a/src/compiler/compiler.py
+++ b/src/compiler/compiler.py
@@ -9,7 +9,7 @@ class Compiler:
     def __init__(self, py_source: str, filename: str) -> None:
         if not (res := self.validate_file(filename)): return
         self.filename = res
-        self.source = self.builtins() + py_source
+        self.source = self.builtins() + py_source.replace('\\\\', '\\')
 
     def validate_file(self, filename: str) -> str|None:
         # TODO: add more validations maybe?


### PR DESCRIPTION
_note: make sure to read the source as raw string_

---
### source
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/097ad23f-766e-45e9-b839-dd4f9c27bb06)
### transpiled
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/9a6cca11-fa78-4f37-ba04-25ed3bb75295)
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/9ed34538-d212-4703-b667-f6930ffd1e1c)
### output
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/30e0a766-072b-4b8a-8f47-f9af16d991a6)
