### PR TITLE
Parse Array Dimensions

### DIFF
--- a/src/lexer/token.py
+++ b/src/lexer/token.py
@@ -1,3 +1,4 @@
+import re
 from constants.constants import DELIMS
 from enum import Enum
 from copy import deepcopy
@@ -412,9 +413,12 @@ class Token:
     def header(self):
         return self._lexeme
 
-    def to_arr(self):
+    def to_arr(self, dimension: int = None):
         'modifies the underlying token'
-        self._lexeme += "[]" if not self._lexeme.endswith("[]") else ""
+        pattern = r".+\[[\d]*\]"  # Matches strings that have [] or [x] in the end
+        match = re.search(pattern, self._lexeme)
+        dimension = max(1, dimension)  # Defaults to 1 for dims < 1
+        self._lexeme += f"[{dimension}]" if not match else ""
         match self.token:
             case TokenType.CHAN:
                 self._token = TokenType.CHAN_ARR

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -306,9 +306,13 @@ class Parser:
 
         # array declaration
         if self.expect_peek(TokenType.OPEN_BRACKET):
-            d.dtype.to_arr()
+            dimension = 1
+            if self.expect_peek(TokenType.INT_LITERAL):
+                dimension = int(self.curr_tok.lexeme)
+            d.dtype.to_arr(dimension)
+
             if not self.expect_peek(TokenType.CLOSE_BRACKET):
-                self.unclosed_bracket_error(self.peek_tok)
+                self.expected_error([TokenType.INT_LITERAL, TokenType.CLOSE_BRACKET])
                 self.advance(2)
                 return None
 
@@ -574,9 +578,13 @@ class Parser:
                 parameters.append(param)
 
                 if self.expect_peek(TokenType.OPEN_BRACKET):
-                    param.dtype.to_arr()
+                    dimension = 1
+                    if self.expect_peek(TokenType.INT_LITERAL):
+                        dimension = int(self.curr_tok.lexeme)
+                    param.dtype.to_arr(dimension)
+
                     if not self.expect_peek(TokenType.CLOSE_BRACKET):
-                        self.unclosed_bracket_error(self.peek_tok)
+                        self.expected_error([TokenType.INT_LITERAL, TokenType.CLOSE_BRACKET])
                         self.advance(2)
                         return None
 


### PR DESCRIPTION
Resolves #273 

Changes:
- to_arr nows injects dimension on top of appending brackets
- modified parsing for decs and params to reflect this
- changed unclosed_bracket_error to expected_error

Preview:
Successful Parsing
![image](https://github.com/Gidsss/UwUIDE/assets/66175571/b809b760-92c8-43dd-97fa-5537eb3fa885)

Errors
![image](https://github.com/Gidsss/UwUIDE/assets/66175571/9076fcd9-f8d8-4626-a46a-9b8caf9fcb3a)
![image](https://github.com/Gidsss/UwUIDE/assets/66175571/9de4086c-acab-4a50-a1fa-0342150ee95d)
