### PR TITLE
int and float literals auto converted to builtin type, more array builtin methods, `.pow()` fix

### DIFF
--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -97,6 +97,11 @@ class TypeChecker:
             'array_type.pop',
             'array_type.prepend',
             'array_type.prextend',
+            'array_type.dimension',
+            'array_type.first',
+            'array_type.last',
+            'array_type.replace',
+            'array_type.shift',
         }
         self.class_signatures.update(
             {
@@ -146,9 +151,14 @@ class TypeChecker:
                 'array_type.count': (Declaration(), Token('chan', TokenType.CHAN), GlobalType.CLASS_METHOD),
                 'array_type.extend': (Declaration(), Token('san', TokenType.SAN), GlobalType.CLASS_METHOD),
                 'array_type.index': (Declaration(), Token('chan', TokenType.CHAN), GlobalType.CLASS_METHOD),
-                'array_type.pop': (Declaration(), Token('san', TokenType.SAN), GlobalType.CLASS_METHOD),
+                'array_type.pop': (Declaration(), Token('gen_arr', TokenType.GEN_ARRAY), GlobalType.CLASS_METHOD),
                 'array_type.prepend': (Declaration(), Token('san', TokenType.SAN), GlobalType.CLASS_METHOD),
                 'array_type.prextend': (Declaration(), Token('san', TokenType.SAN), GlobalType.CLASS_METHOD),
+                'array_type.dimension': (Declaration(), Token('chan', TokenType.CHAN), GlobalType.CLASS_METHOD),
+                'array_type.first': (Declaration(), Token('gen_arr', TokenType.GEN_ARRAY), GlobalType.CLASS_METHOD),
+                'array_type.last': (Declaration(), Token('gen_arr', TokenType.GEN_ARRAY), GlobalType.CLASS_METHOD),
+                'array_type.replace': (Declaration(), Token('san', TokenType.SAN), GlobalType.CLASS_METHOD),
+                'array_type.shift': (Declaration(), Token('gen_arr', TokenType.GEN_ARRAY), GlobalType.CLASS_METHOD),
             },
         )
         self.class_method_param_types.update(
@@ -202,6 +212,11 @@ class TypeChecker:
                 'array_type.pop': [],
                 'array_type.prepend': [Token('elem', TokenType.ARRAY_ELEMENT)],
                 'array_type.prextend': [Token('gen_arr', TokenType.GEN_ARRAY)],
+                'array_type.dimension': [],
+                'array_type.first': [Token('chan', TokenType.CHAN)],
+                'array_type.last': [Token('chan', TokenType.CHAN)],
+                'array_type.replace': [Token('elem', TokenType.ARRAY_ELEMENT), Token('elem', TokenType.ARRAY_ELEMENT)],
+                'array_type.shift': [],
             }
         )
 

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -151,14 +151,14 @@ class TypeChecker:
                 'array_type.count': (Declaration(), Token('chan', TokenType.CHAN), GlobalType.CLASS_METHOD),
                 'array_type.extend': (Declaration(), Token('san', TokenType.SAN), GlobalType.CLASS_METHOD),
                 'array_type.index': (Declaration(), Token('chan', TokenType.CHAN), GlobalType.CLASS_METHOD),
-                'array_type.pop': (Declaration(), Token('gen_arr', TokenType.GEN_ARRAY), GlobalType.CLASS_METHOD),
+                'array_type.pop': (Declaration(), Token('elem', TokenType.ARRAY_ELEMENT), GlobalType.CLASS_METHOD),
                 'array_type.prepend': (Declaration(), Token('san', TokenType.SAN), GlobalType.CLASS_METHOD),
                 'array_type.prextend': (Declaration(), Token('san', TokenType.SAN), GlobalType.CLASS_METHOD),
                 'array_type.dimension': (Declaration(), Token('chan', TokenType.CHAN), GlobalType.CLASS_METHOD),
                 'array_type.first': (Declaration(), Token('gen_arr', TokenType.GEN_ARRAY), GlobalType.CLASS_METHOD),
                 'array_type.last': (Declaration(), Token('gen_arr', TokenType.GEN_ARRAY), GlobalType.CLASS_METHOD),
                 'array_type.replace': (Declaration(), Token('san', TokenType.SAN), GlobalType.CLASS_METHOD),
-                'array_type.shift': (Declaration(), Token('gen_arr', TokenType.GEN_ARRAY), GlobalType.CLASS_METHOD),
+                'array_type.shift': (Declaration(), Token('elem', TokenType.ARRAY_ELEMENT), GlobalType.CLASS_METHOD),
             },
         )
         self.class_method_param_types.update(
@@ -837,10 +837,9 @@ class TypeChecker:
         self.check_call_args(GlobalType.CLASS_METHOD, method_signature, fn_call.id,
                              fn_call.args, expected_types, all_defs, class_type)
         match return_type.token:
-            case TokenType.GEN_ARRAY:
-                return class_type
-            case _:
-                return Token.from_type(return_type.token)
+            case TokenType.GEN_ARRAY: return class_type
+            case TokenType.ARRAY_ELEMENT: return class_type.to_unit_type()
+            case _: return Token.from_type(return_type.token)
 
     def check_call_args(self, global_type: GlobalType, call_str: str, id: Token, call_args: list[Value], expected_types: list[Token],
                         local_defs: dict[str, tuple[Declaration, Token, GlobalType]], self_type: Token= Token()) -> None:
@@ -902,8 +901,9 @@ class TypeChecker:
         match ret_type:
             case TokenType.GEN_ARRAY:
                 return self_type if self_type.exists() else Token.from_type(TokenType.SAN)
-            case _:
-                return Token.from_type(ret_type)
+            case TokenType.ARRAY_ELEMENT:
+                return self_type.to_unit_type() if self_type.exists() else Token.from_type(TokenType.SAN)
+            case _: return Token.from_type(ret_type)
 
     def check_class_constructor(self, class_constructor: ClassConstructor, local_defs: dict[str, tuple[Declaration, Token, GlobalType]]) -> None:
         expected_types = self.class_param_types[class_constructor.id.flat_string()]

--- a/src/builtin/types/iterable.py
+++ b/src/builtin/types/iterable.py
@@ -119,8 +119,10 @@ class String:
         return [str, String]
 
 class Array:
-    def __init__(self, vals: list):
-        self.val: list = vals
+    def __init__(self, vals: "list|Array"):
+        tmp: "list|Array" = vals
+        while isinstance(tmp, Array): tmp = tmp.val
+        self.val: list = tmp
 
     ## META DUNDER METHODS
     # basic properties

--- a/src/builtin/types/iterable.py
+++ b/src/builtin/types/iterable.py
@@ -182,13 +182,34 @@ class Array:
     def _index(self, item) -> Int:
         if item not in self.val: return Int(-1)
         return Int(self.val.index(item))
-    def _pop(self) -> None:
-        if len(self.val) == 0: return
-        _ = self.val.pop()
+    def _pop(self):
+        if len(self.val) == 0: return Array([])
+        return Array([self.val.pop()])
     def _prepend(self, item) -> None:
         self.val.insert(0, item)
     def _prextend(self, item) -> None:
         self.val = item + self.val
+    def _dimension(self) -> Int:
+        dimension = 0
+        tmp = self.val
+        while isinstance(tmp, list):
+            dimension += 1
+            if len(tmp) == 0: break
+            tmp = tmp[0]
+            if not isinstance(tmp, Array): break
+            tmp = tmp.val
+        return Int(dimension)
+    def _first(self, n) -> Array:
+        idx = max(int(n), 0)
+        return Array(self.val[:idx])
+    def _last(self, n) -> Array:
+        idx = max(int(n), 0)
+        return Array(self.val[-idx:])
+    def _replace(self, old, new) -> None:
+        self.val = [new if x == old else x for x in self.val]
+    def _shift(self):
+        if len(self.val) == 0: return Array([])
+        return Array([self.val.pop(0)])
 
     ## UTILS
     def valid_operands(self) -> list[type]:

--- a/src/builtin/types/iterable.py
+++ b/src/builtin/types/iterable.py
@@ -129,7 +129,10 @@ class Array:
     def __len__(self):
         return len(self.val)
     def __str__(self):
-        return str(self.val)
+        res = "{"
+        for val in self.val: res += str(val) + ", "
+        res = (res[:-2] if res[-2:] == ", " else res) + "}"
+        return res
     def __repr__(self):
         return repr(self.val)
 

--- a/src/builtin/types/iterable.py
+++ b/src/builtin/types/iterable.py
@@ -183,8 +183,8 @@ class Array:
         if item not in self.val: return Int(-1)
         return Int(self.val.index(item))
     def _pop(self):
-        if len(self.val) == 0: return Array([])
-        return Array([self.val.pop()])
+        if len(self.val) == 0: raise PopError("OwO...Tried to pop from an empty array!!!!!")
+        return self.val.pop()
     def _prepend(self, item) -> None:
         self.val.insert(0, item)
     def _prextend(self, item) -> None:
@@ -208,15 +208,16 @@ class Array:
     def _replace(self, old, new) -> None:
         self.val = [new if x == old else x for x in self.val]
     def _shift(self):
-        if len(self.val) == 0: return Array([])
-        return Array([self.val.pop(0)])
+        if len(self.val) == 0: raise ShiftError("OwO...Tried to shift from an empty array!!!!!")
+        return self.val.pop(0)
 
     ## UTILS
     def valid_operands(self) -> list[type]:
         return [list, Array]
 
-class TypeError(Exception):
-    pass
+class TypeError(Exception):...
+class PopError(Exception):...
+class ShiftError(Exception):...
 def expect_type_is_in(actual, expecteds: list[type], msg: str):
     if type(actual) not in expecteds:
         raise TypeError(f"{msg}\nExpected any in {expecteds} !!\nGot {type(actual)} !!!")

--- a/src/builtin/types/number.py
+++ b/src/builtin/types/number.py
@@ -76,6 +76,18 @@ class Bool:
         except:
             raise ValueError(f"Oh no!! '{other}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
         return type(self)(res % self.val)
+    def __pow__(self, other) -> Bool:
+        try:
+            res = int(float(other))
+        except:
+            raise ValueError(f"Oh no!! '{other}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
+        return type(self)(self.val ** res)
+    def __rpow__(self, other) -> Bool:
+        try:
+            res = int(float(other))
+        except:
+            raise ValueError(f"Oh no!! '{other}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
+        return type(self)(res ** self.val)
     def __neg__(self) -> Bool:
         return type(self)(-self.val)
     def __lt__(self, other) -> Bool:
@@ -214,6 +226,18 @@ class Float:
         except:
             raise ValueError(f"Oh no!! '{other}' cannot be converted to kuuuuuuuunnnnnnn!!")
         return type(self)(self.cap_val(res % self.val))
+    def __pow__(self, other) -> Float:
+        try:
+            res = float(other)
+        except:
+            raise ValueError(f"Oh no!! '{other}' cannot be converted to kuuuuuuuunnnnnnn!!")
+        return type(self)(self.cap_val(self.val ** res))
+    def __rpow__(self, other) -> Float:
+        try:
+            res = float(other)
+        except:
+            raise ValueError(f"Oh no!! '{other}' cannot be converted to kuuuuuuuunnnnnnn!!")
+        return type(self)(self.cap_val(res ** self.val))
     def __neg__(self) -> Float:
         return type(self)(-self.val)
     def __lt__(self, other) -> Bool:
@@ -400,6 +424,24 @@ class Int:
             case float(): return Float(float(self.cap_val(other % self.val)))
             case Float(): return Float(float(self.cap_val(other.val % self.val)))
             case _: return type(self)(self.cap_val(res % self.val))
+    def __pow__(self, other) -> Int | Float:
+        try:
+            res = int(float(other))
+        except:
+            raise ValueError(f"Oh no!! '{other}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
+        match other:
+            case float(): return Float(float(self.cap_val(self.val ** other)))
+            case Float(): return Float(float(self.cap_val(self.val ** other.val)))
+            case _: return type(self)(self.cap_val(self.val ** res))
+    def __rpow__(self, other) -> Int | Float:
+        try:
+            res = int(float(other))
+        except:
+            raise ValueError(f"Oh no!! '{other}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
+        match other:
+            case float(): return Float(float(self.cap_val(other ** self.val)))
+            case Float(): return Float(float(self.cap_val(other.val ** self.val)))
+            case _: return type(self)(self.cap_val(res ** self.val))
     def __neg__(self) -> Int:
         return type(self)(-self.val)
     def __lt__(self, other) -> Bool:

--- a/src/lexer/token.py
+++ b/src/lexer/token.py
@@ -320,6 +320,7 @@ class Token:
         return self._lexeme
     def python_string(self, indent = 1, cwass=False) -> str:
         match self.token:
+            # for possibly class members
             case UniqueTokenType():
                 global class_properties
                 res = ""
@@ -328,6 +329,7 @@ class Token:
                     res = "self."
                 res += f"_{self.lexeme}"
                 return res
+            # no python equivalent
             case (TokenType.GWOBAW
                 | TokenType.DONO
                 | TokenType.DOUBLE_OPEN_BRACKET
@@ -335,9 +337,8 @@ class Token:
                 | TokenType.TERMINATOR
             ):
                 return ""
-            case (TokenType.INT_LITERAL
-                | TokenType.FLOAT_LITERAL
-                | TokenType.ASSIGNMENT_OPERATOR
+            # transpile literally
+            case (TokenType.ASSIGNMENT_OPERATOR
                 | TokenType.ADDITION_SIGN
                 | TokenType.DASH
                 | TokenType.MULTIPLICATION_SIGN
@@ -357,6 +358,10 @@ class Token:
                 | TokenType.DOT_OP
             ):
                 return self.lexeme
+            case TokenType.INT_LITERAL:
+                return f"Int({self.lexeme})"
+            case TokenType.FLOAT_LITERAL:
+                return f"Float({self.lexeme})"
             case TokenType.STRING_LITERAL:
                 return f"String({self.lexeme})"
             case TokenType.MAINUWU:
@@ -385,23 +390,20 @@ class Token:
                 return "break"
             case TokenType.CHAN:
                 return "Int"
-            case TokenType.CHAN_ARR:
-                return "Array"
             case TokenType.KUN:
                 return "Float"
-            case TokenType.KUN_ARR:
-                return "Array"
             case TokenType.SAMA:
                 return "Bool"
-            case TokenType.SAMA_ARR:
-                return "Array"
             case TokenType.SAN:
                 return "NoneType"
-            case TokenType.SAN_ARR:
-                return "Array"
             case TokenType.SENPAI:
                 return "String"
-            case TokenType.SENPAI_ARR:
+            case (TokenType.CHAN_ARR
+                | TokenType.KUN_ARR
+                | TokenType.SAMA_ARR
+                | TokenType.SAN_ARR
+                | TokenType.SENPAI_ARR
+            ):
                 return "Array"
             case TokenType.NUWW:
                 return "None"


### PR DESCRIPTION
closes #277
closes #276
closes #271  

---
## changes
1. More `Array` builtin methods
    - specified at #277 
2. int and float literals are auto converted to `Int` and `Float` respectively at a literal level
    - _just like `Bool`, `String`, and `Array`s_
3. all builtin number types have `__pow__()` and `__rpow__()` methods now
---
## test log
### source
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/d2043498-940a-4afc-9a45-be49276f5f6a)
### transpiled
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/85ad3c6c-7d7e-4c72-8b28-bf5a0086e46a)
### output
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/75df1a00-ffb7-4412-929d-c1a547fd0aa0)

