### PR TITLE
feat: able to assign to a subscripted string

### DIFF
--- a/src/builtin/types/iterable.py
+++ b/src/builtin/types/iterable.py
@@ -55,6 +55,8 @@ class String:
     # subscripting
     def __getitem__(self, index):
         return self.val[index]
+    def __setitem__(self, index, item):
+        self.val = self.val.replace(str(self.val[index]), str(item))
     def __contains__(self, item):
         return item in self.val
     def __iter__(self):


### PR DESCRIPTION
closes #279 if ever the team decides to allow string mutability

---
# string subscripts can be assigned to
```
a-senpai = "1123"~
a{0} = "09 "~

pwint(a)~
>.< output: "09 123"
```

---
### source
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/0b9b637d-46b2-422a-b042-cd011fa4c08a)
### transpiled
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/48a837de-6380-44ab-bab7-aa84e4d4ffb6)
### output
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/9a5b4d68-792f-496f-9169-f4f42b038674)
### output 2
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/c46120e6-1bee-45f6-a267-cb68d45c1f17)

