### PR TITLE
Feat/even more array builtin methods

### DIFF
--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -99,6 +99,8 @@ class TypeChecker:
             'array_type.prextend',
             'array_type.dimension',
             'array_type.first',
+            'array_type.flatten',
+            'array_type.join',
             'array_type.last',
             'array_type.replace',
             'array_type.shift',
@@ -156,6 +158,8 @@ class TypeChecker:
                 'array_type.prextend': (Declaration(), Token('san', TokenType.SAN), GlobalType.CLASS_METHOD),
                 'array_type.dimension': (Declaration(), Token('chan', TokenType.CHAN), GlobalType.CLASS_METHOD),
                 'array_type.first': (Declaration(), Token('gen_arr', TokenType.GEN_ARRAY), GlobalType.CLASS_METHOD),
+                'array_type.flatten': (Declaration(), Token('one_d_arr', TokenType.ONE_D_ARRAY), GlobalType.CLASS_METHOD),
+                'array_type.join': (Declaration(), Token('senpai', TokenType.SENPAI), GlobalType.CLASS_METHOD),
                 'array_type.last': (Declaration(), Token('gen_arr', TokenType.GEN_ARRAY), GlobalType.CLASS_METHOD),
                 'array_type.replace': (Declaration(), Token('san', TokenType.SAN), GlobalType.CLASS_METHOD),
                 'array_type.shift': (Declaration(), Token('elem', TokenType.ARRAY_ELEMENT), GlobalType.CLASS_METHOD),
@@ -214,6 +218,8 @@ class TypeChecker:
                 'array_type.prextend': [Token('gen_arr', TokenType.GEN_ARRAY)],
                 'array_type.dimension': [],
                 'array_type.first': [Token('chan', TokenType.CHAN)],
+                'array_type.flatten': [],
+                'array_type.join': [Token('senpai', TokenType.SENPAI)],
                 'array_type.last': [Token('chan', TokenType.CHAN)],
                 'array_type.replace': [Token('elem', TokenType.ARRAY_ELEMENT), Token('elem', TokenType.ARRAY_ELEMENT)],
                 'array_type.shift': [],
@@ -855,6 +861,9 @@ class TypeChecker:
         match return_type.token:
             case TokenType.GEN_ARRAY: return class_type
             case TokenType.ARRAY_ELEMENT: return class_type.to_unit_type()
+            case TokenType.ONE_D_ARRAY:
+                while class_type.dimension() > 1: class_type = class_type.to_unit_type()
+                return class_type
             case _: return return_type
 
     def check_call_args(self, global_type: GlobalType, call_str: str, id: Token, call_args: list[Value], expected_types: list[Token],
@@ -919,6 +928,11 @@ class TypeChecker:
                 return self_type if self_type.exists() else Token.from_type(TokenType.SAN)
             case TokenType.ARRAY_ELEMENT:
                 return self_type.to_unit_type() if self_type.exists() else Token.from_type(TokenType.SAN)
+            case TokenType.ONE_D_ARRAY:
+                if self_type.exists():
+                    while self_type.dimension() > 1: self_type = self_type.to_unit_type()
+                    return self_type
+                else: return Token.from_type(TokenType.SAN)
             case _: return ret_type
 
     def check_class_constructor(self, class_constructor: ClassConstructor, local_defs: dict[str, tuple[Declaration, Token, GlobalType]]) -> None:

--- a/src/builtin/types/iterable.py
+++ b/src/builtin/types/iterable.py
@@ -202,6 +202,17 @@ class Array:
     def _first(self, n) -> Array:
         idx = max(int(n), 0)
         return Array(self.val[:idx])
+    def _flatten(self) -> Array:
+        def flatten(arr: list|Array) -> list:
+            flattened = []
+            for item in arr:
+                match item:
+                    case list() | Array(): flattened.extend(flatten(item))
+                    case _: flattened.append(item)
+            return flattened
+        return Array(flatten(self.val))
+    def _join(self, separator: String) -> String:
+        return String(str(separator).join([str(val) for val in self._flatten()]))
     def _last(self, n) -> Array:
         idx = max(int(n), 0)
         return Array(self.val[-idx:])

--- a/src/lexer/token.py
+++ b/src/lexer/token.py
@@ -206,12 +206,15 @@ class TokenType(Enum):
     WHITESPACE = ("WHITESPACE", "all")
     EOF = ("EOF", "all")
 
-    # for `append()` type checking
+    # for array methods accepting the unit type of the array type
     ARRAY_ELEMENT = ("elem", "all")
-    # for `extend()` type checking
+    # for array methods accepting same array type
     GEN_ARRAY = ("gen_arr", "all")
-    # for `pow()` type checking
+    # for number methods (could've just used chan tbh...)
     NUMBER = ("num", "all")
+    # for `flatten()` type checking
+    ONE_D_ARRAY = ("one_d_arr", "all")
+
 
 class UniqueTokenType:
     """


### PR DESCRIPTION
closes #284 
> 1. `flatten-one_d_array()`
>     - flattens the array to one dimension
>     - if already one dimension, will do nothing
>     - returns a one dimension variant of the current array type
> 2. `join-senpai(separator-senpai)`
>     - use `flatten()` to flatten the array to one dimension, converts each element into `senpai`, then combines all elements with the provided separator
---
## test code
### source
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/5b0e2af8-6bda-4d00-b5f2-9fb0b84bc21a)
### transpiled
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/a75f38c0-99d3-48e4-b039-ad8e8426a4bf)
### output
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/4105480e-ecf4-4a2e-85f4-bfb87353696a)
