### PR TITLE
Format all array dimension  of 1 to empty brackets

### DIFF
--- a/src/lexer/token.py
+++ b/src/lexer/token.py
@@ -444,6 +444,8 @@ class Token:
     def formatted_string(self, indent=0) -> str:
         if self.token == TokenType.STRING_LITERAL:
             return self.lexeme.replace("\\\\", "\\").replace("|", "\|")
+        if self.lexeme.endswith("[1]"):
+            return self.lexeme.replace("[1]", "[]")
         return self.lexeme
 
     def header(self):

--- a/src/parser/productions.py
+++ b/src/parser/productions.py
@@ -508,7 +508,7 @@ class Declaration(Statement):
         if self.is_global:
             res += "gwobaw "
 
-        res += f"{self.id}-{self.dtype}"
+        res += f"{self.id}-{self.dtype.formatted_string()}"
         if self.dono_token.exists():
             res += "-dono"
 


### PR DESCRIPTION
## Changes:
- all array declarations that have a dimension of 1 will be formatted to array[]
- for example:
```
a-chan[] => a-chan[]
a-chan[1] => a-chan[]
```

Let me know if this is alright

## Preview
Before:
![image](https://github.com/Gidsss/UwUIDE/assets/66175571/d6586cb8-cd81-415c-a495-155d2d8132d3)

After:
![image](https://github.com/Gidsss/UwUIDE/assets/66175571/f2046aff-572c-4ef2-ab60-3af766f7d74a)

