### PR TITLE
fix: empty `inpwt()` converted to `String`, `String.split()` takes no args, `Bool` math ops should return `Int` and `Float`

### DIFF
--- a/src/builtin/types/iterable.py
+++ b/src/builtin/types/iterable.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from .namespace import Int, Bool
 
 class String:
-    def __init__(self, val: str):
+    def __init__(self, val: str = ""):
         self.val: str = str(val)
 
     ## META DUNDER METHODS

--- a/src/builtin/types/iterable.py
+++ b/src/builtin/types/iterable.py
@@ -89,8 +89,8 @@ class String:
         return type(self)(self.val.replace(str(old), str(new)))
     def _strip(self) -> String:
         return type(self)(self.val.strip())
-    def _split(self, item: str) -> Array:
-        return Array([type(self)(x) for x in self.val.split(str(item))])
+    def _split(self) -> Array:
+        return Array([type(self)(x) for x in self.val.split(" ")])
     def _swapcase(self) -> String:
         return type(self)(self.val.swapcase())
     def _title(self) -> String:

--- a/src/builtin/types/number.py
+++ b/src/builtin/types/number.py
@@ -16,80 +16,123 @@ class Bool:
         return self.__str__()
 
     # operator overloading
-    def __add__(self, other) -> Bool:
-        try:
-            res = int(float(other))
-        except:
-            raise ValueError(f"Oh no!! '{other}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
-        return type(self)(self.val + res)
-    def __radd__(self, other) -> Bool:
-        try:
-            res = int(float(other))
-        except:
-            raise ValueError(f"Oh no!! '{other}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
-        return type(self)(res + self.val)
-    def __sub__(self, other) -> Bool:
-        try:
-            res = int(float(other))
-        except:
-            raise ValueError(f"Oh no!! '{other}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
-        return type(self)(self.val - res)
-    def __rsub__(self, other) -> Bool:
-        try:
-            res = int(float(other))
-        except:
-            raise ValueError(f"Oh no!! '{other}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
-        return type(self)(res - self.val)
-    def __mul__(self, other) -> Bool:
-        try:
-            res = int(float(other))
-        except:
-            raise ValueError(f"Oh no!! '{other}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
-        return type(self)(self.val * res)
-    def __rmul__(self, other) -> Bool:
-        try:
-            res = int(float(other))
-        except:
-            raise ValueError(f"Oh no!! '{other}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
-        return type(self)(res * self.val)
-    def __truediv__(self, other) -> Bool:
-        try:
-            res = float(other)
-        except:
-            raise ValueError(f"Oh no!! '{other}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
-        return type(self)(self.val / res)
-    def __rtruediv__(self, other) -> Bool:
-        try:
-            res = float(other)
-        except:
-            raise ValueError(f"Oh no!! '{other}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
-        return type(self)(res / self.val)
-    def __mod__(self, other) -> Bool:
-        try:
-            res = int(float(other))
-        except:
-            raise ValueError(f"Oh no!! '{other}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
-        return type(self)(self.val % res)
-    def __rmod__(self, other) -> Bool:
-        try:
-            res = int(float(other))
-        except:
-            raise ValueError(f"Oh no!! '{other}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
-        return type(self)(res % self.val)
-    def __pow__(self, other) -> Bool:
-        try:
-            res = int(float(other))
-        except:
-            raise ValueError(f"Oh no!! '{other}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
-        return type(self)(self.val ** res)
-    def __rpow__(self, other) -> Bool:
-        try:
-            res = int(float(other))
-        except:
-            raise ValueError(f"Oh no!! '{other}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
-        return type(self)(res ** self.val)
-    def __neg__(self) -> Bool:
-        return type(self)(-self.val)
+    def __add__(self, other) -> Int | Float:
+        match other:
+            case int() | Int(): return Int(self.val + int(other))
+            case float() | Float(): return Float(self.val + float(other))
+            case Bool(): return Int(self.val + int(other))
+            case _:
+                try: res = int(float(other))
+                except: raise ValueError(f"Oh no!! '{other}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
+                return Int(self.val + res)
+    def __radd__(self, other) -> Int | Float:
+        match other:
+            case int() | Int(): return Int(int(other) + self.val)
+            case float() | Float(): return Float(float(other) + self.val)
+            case Bool(): return Int(int(other) + self.val)
+            case _:
+                try: res = int(float(other))
+                except: raise ValueError(f"Oh no!! '{other}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
+                return Int(res + self.val)
+    def __sub__(self, other) -> Int | Float:
+        match other:
+            case int() | Int(): return Int(self.val - int(other))
+            case float() | Float(): return Float(self.val - float(other))
+            case Bool(): return Int(self.val - int(other))
+            case _:
+                try: res = int(float(other))
+                except: raise ValueError(f"Oh no!! '{other}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
+                return Int(self.val - res)
+    def __rsub__(self, other) -> Int | Float:
+        match other:
+            case int() | Int(): return Int(int(other) - self.val)
+            case float() | Float(): return Float(float(other) - self.val)
+            case Bool(): return Int(int(other) - self.val)
+            case _:
+                try: res = int(float(other))
+                except: raise ValueError(f"Oh no!! '{other}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
+                return Int(res - self.val)
+    def __mul__(self, other) -> Int | Float:
+        match other:
+            case int() | Int(): return Int(self.val * int(other))
+            case float() | Float(): return Float(self.val * float(other))
+            case Bool(): return Int(self.val * int(other))
+            case _:
+                try: res = int(float(other))
+                except: raise ValueError(f"Oh no!! '{other}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
+                return Int(self.val * res)
+    def __rmul__(self, other) -> Int | Float:
+        match other:
+            case int() | Int(): return Int(int(other) * self.val)
+            case float() | Float(): return Float(float(other) * self.val)
+            case Bool(): return Int(int(other) * self.val)
+            case _:
+                try: res = int(float(other))
+                except: raise ValueError(f"Oh no!! '{other}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
+                return Int(res * self.val)
+    def __truediv__(self, other) -> Int | Float:
+        match other:
+            case int() | Int(): return Float(self.val / int(other))
+            case float() | Float(): return Float(self.val / float(other))
+            case Bool(): return Float(self.val / int(other))
+            case _:
+                try: res = int(float(other))
+                except: raise ValueError(f"Oh no!! '{other}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
+                return Float(self.val / res)
+    def __rtruediv__(self, other) -> Int | Float:
+        match other:
+            case int() | Int(): return Float(int(other) / self.val)
+            case float() | Float(): return Float(float(other) / self.val)
+            case Bool(): return Float(int(other) / self.val)
+            case _:
+                try: res = int(float(other))
+                except: raise ValueError(f"Oh no!! '{other}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
+                return Float(res / self.val)
+    def __mod__(self, other) -> Int | Float:
+        match other:
+            case int() | Int(): return Int(self.val % int(other))
+            case float() | Float(): return Float(self.val % float(other))
+            case Bool(): return Int(self.val % int(other))
+            case _:
+                try: res = int(float(other))
+                except: raise ValueError(f"Oh no!! '{other}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
+                return Int(self.val % res)
+    def __rmod__(self, other) -> Int | Float:
+        match other:
+            case int() | Int(): return Int(int(other) % self.val)
+            case float() | Float(): return Float(float(other) % self.val)
+            case Bool(): return Int(int(other) % self.val)
+            case _:
+                try: res = int(float(other))
+                except: raise ValueError(f"Oh no!! '{other}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
+                return Int(res % self.val)
+    def __pow__(self, other) -> Int | Float:
+        match other:
+            case int() | Int(): return Int(self.val ** int(other))
+            case float() | Float(): return Float(self.val ** float(other))
+            case Bool(): return Int(self.val ** int(other))
+            case _:
+                try: res = int(float(other))
+                except: raise ValueError(f"Oh no!! '{other}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
+                return Int(self.val ** res)
+    def __rpow__(self, other) -> Int | Float:
+        match other:
+            case int() | Int(): return Int(int(other) ** self.val)
+            case float() | Float(): return Float(float(other) ** self.val)
+            case Bool(): return Int(int(other) ** self.val)
+            case _:
+                try: res = int(float(other))
+                except: raise ValueError(f"Oh no!! '{other}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
+                return Int(res ** self.val)
+    def __neg__(self) -> Int | Float:
+        match self.val:
+            case int(): return Int(-self.val)
+            case float(): return Float(-self.val)
+            case Bool(): return Int(-int(self.val))
+            case _:
+                try: res = int(float(self.val))
+                except: raise ValueError(f"Oh no!! '{self.val}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
+                return Int(-res)
     def __lt__(self, other) -> Bool:
         try:
             res = int(float(other))

--- a/src/builtin/types/number.py
+++ b/src/builtin/types/number.py
@@ -300,8 +300,13 @@ class Float:
     ## BUILTIN METHODS
     def _abs(self) -> Float:
         return type(self)(self.cap_val(abs(self.val)))
-    def _pow(self, other: int|float) -> Float:
-        return type(self)(self.cap_val(self.val ** other))
+    def _pow(self, other) -> Float:
+        match other:
+            case float() | Float(): res = float(other)
+            case int() | Int(): res = int(other)
+            case bool() | Bool(): res = int(other)
+            case _: raise ValueError(f"Oh no!! '{self.val}' cannot be converted to kuuuuuuuunnnnnnn!!")
+        return type(self)(self.cap_val(self.val ** res))
     def _sqrt(self) -> Float:
         return type(self)(float((self.cap_val(sqrt(self.val))).__floor__()))
     def _isNegative(self) -> Bool:
@@ -493,7 +498,7 @@ class Int:
             res = int(self.val)
             return res
         except:
-            raise ValueError(f"Oh no!! '{self.val}' cannot be converted to kuuuuuuuunnnnnnn!!")
+            raise ValueError(f"Oh no!! '{self.val}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
     def __float__(self):
         try:
             res = float(self.val)
@@ -504,8 +509,13 @@ class Int:
     ## BUILTIN METHODS
     def _abs(self) -> Int:
         return type(self)(self.cap_val(abs(self.val)))
-    def _pow(self, other: int|float) -> Int:
-        return type(self)(self.cap_val(self.val ** other))
+    def _pow(self, other) -> Int:
+        match other:
+            case float() | Float(): res = float(other)
+            case int() | Int(): res = int(other)
+            case bool() | Bool(): res = int(other)
+            case _: raise ValueError(f"Oh no!! '{self.val}' cannot be converted to chaaaaaaaaannnnnnnnnn!!")
+        return type(self)(self.cap_val(self.val ** res))
     def _sqrt(self) -> Int:
         return type(self)(self.cap_val(int(sqrt(self.val))))
     def _isNegative(self) -> Bool:


### PR DESCRIPTION
closes #294
closes #295

---
### changes
1. `String.split()` now properly doesn't take in a separator argument
2. empty `inpwt()` now gets properly converted to `String`
3. `Bool` math op dunder methods return `Int` or `Float` instead of `Bool` which would cap the value no matter which operation it did