### PR TITLE
Fix/check whether fn or method call

### DIFF
--- a/src/analyzer/error_handler.py
+++ b/src/analyzer/error_handler.py
@@ -381,7 +381,7 @@ class ReassignedConstantError:
         self.token = token
         self.defined_token = defined_token
         self.header = header
-        self.msg = token_msg + '\n'
+        self.msg = token_msg
 
     def position(self) -> tuple[int, int]|None:
         return self.token.position
@@ -406,7 +406,7 @@ class ReassignedConstantError:
         msg += f"\t{' ' * max_pad} | {'_' * (self.defined_token.position[1])}|\n"
         msg += f"\t{' ' * max_pad} | |\n"
         msg += f"\t{' ' * max_pad} | |\t"
-        msg += self.msg
+        msg += self.msg + "\n"
         msg += f"\t{index_str:{max_pad}} | |{ErrorSrc.src[self.token.position[0]]}\n"
         msg += f"\t{' ' * max_pad} | |{' ' * self.token.position[1]}{'^' * (error_range)}\n"
         msg += f"\t{' ' * max_pad} | |{'_' * (self.token.position[1])}|\n"

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -947,12 +947,14 @@ class TypeChecker:
                         expected_types_str.append("chan, kun, or sama")
                     case _:
                         expected_types_str.append(f"{e}")
+            try: id_definition = local_defs[call_str].dtype
+            except: id_definition = self.class_signatures[call_str].dtype
             self.errors.append(
                 MismatchedCallArgType(
                     global_type=global_type,
                     call_str=call_str if not self_type.exists() else call_str.replace("array_type", self_type.flat_string()),
                     id=id,
-                    id_definition=local_defs[call_str][1] if call_str not in self.builtin_signatures else None,
+                    id_definition=id_definition if call_str not in self.builtin_signatures else None,
                     expected_types=expected_types_str,
                     args=call_args,
                     actual_types=actual_types,

--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -962,14 +962,16 @@ class TypeChecker:
 
     def evaluate_fn_call(self, fn_call: FnCall, local_defs: dict[str, Signature],
                          *, self_type: Token = Token()) -> Token:
-        if self.in_class_type.exists():
-            fn_call.need_self = True
+        try:
             expected_types = self.class_method_param_types[f"{self.in_class_type.flat_string()}.{fn_call.id.flat_string()}"]
-            ret_type = self.class_signatures[f"{self.in_class_type.flat_string()}.{fn_call.id.flat_string()}"][1]
-        else:
+            ret_type = self.class_signatures[f"{self.in_class_type.flat_string()}.{fn_call.id.flat_string()}"].dtype
+            fn_call.need_self = True
+            call_str = f"{self.in_class_type.flat_string()}.{fn_call.id.flat_string()}"
+        except:
             expected_types = self.function_param_types[fn_call.id.flat_string()]
-            ret_type = local_defs[fn_call.id.flat_string()][1]
-        self.check_call_args(GlobalType.FUNCTION, fn_call.id.flat_string(), fn_call.id, fn_call.args, expected_types, local_defs)
+            ret_type = local_defs[fn_call.id.flat_string()].dtype
+            call_str = fn_call.id.flat_string()
+        self.check_call_args(GlobalType.FUNCTION, call_str, fn_call.id, fn_call.args, expected_types, local_defs)
         match ret_type:
             case TokenType.GEN_ARRAY:
                 return self_type if self_type.exists() else Token.from_type(TokenType.SAN)


### PR DESCRIPTION
# now properly differentiates whether an fn call inside class bodies are fn or method calls
### source
```python
sample text file
-------------------------------------------------------------------
1 |
2 | fwunc mainuwu-san() [[
3 |    num-Divide = Divide()~
4 |    pwint("halved: |num.halved(10)|")~
5 |    pwint("quartered: |num.quartered(10)|")~
6 | ]]
7 |
8 | cwass Divide() [[
9 |     fwunc halved-kun(x-chan) [[
10 |         pwint(randomInt(1,2))~
11 |         pwint(sum())~
12 |         pwint(test())~
13 |         wetuwn(x / 2)~
14 |     ]]
15 |     fwunc quartered-kun(x-chan) [[ wetuwn((halved(x) / 4))~ ]]
16 |     fwunc test-chan() [[ wetuwn(1)~ ]]
17 | ]]
18 | fwunc sum-chan() [[ wetuwn(0)~ ]]
19 |
-------------------------------------------------------------------
end of file
```
### transpiled before
```python
def main():
    _num: _Divide = _Divide()
    print(String(f"halved: {_num._halved(Int(10))}"))
    print(String(f"quartered: {_num._quartered(Int(10))}"))

class _Divide:
    def __repr__(self):
        return f"{self.__class__.__name__[1:]}({', '.join(f'{key[1:]}={value}' for key, value in self.__dict__.items())})"
    def __str__(self):
        return f"{self.__class__.__name__[1:]}({', '.join(f'{key[1:]}={value}' for key, value in self.__dict__.items())})"
    def _halved(self, _x: Int):
        _x: Int = Int(_x)
        print(self._randomInt(Int(1), Int(2)))
        print(self._sum())
        print(self._test())
        return (_x / Int(2))

    def _quartered(self, _x: Int):
        _x: Int = Int(_x)
        return (self._halved(_x) / Int(4))

    def _test(self):
        return Int(1)

def _sum():
    return Int(0)

if __name__ == '__main__':
    # clear screen before executing
    import platform
    import os
    os.system('cls' if platform.system() == 'Windows' else 'clear')

    # declare globals
    main()
```
_take note in `halved()`, all fn calls are assumed to be self calls even though its not defined in class scope_

### transpiled after
```python
def main():
    _num: _Divide = _Divide()
    print(String(f"halved: {_num._halved(Int(10))}"))
    print(String(f"quartered: {_num._quartered(Int(10))}"))

class _Divide:
    def __repr__(self):
        return f"{self.__class__.__name__[1:]}({', '.join(f'{key[1:]}={value}' for key, value in self.__dict__.items())})"
    def __str__(self):
        return f"{self.__class__.__name__[1:]}({', '.join(f'{key[1:]}={value}' for key, value in self.__dict__.items())})"
    def _halved(self, _x: Int):
        _x: Int = Int(_x)
        print(_randomInt(Int(1), Int(2)))
        print(_sum())
        print(self._test())
        return (_x / Int(2))

    def _quartered(self, _x: Int):
        _x: Int = Int(_x)
        return (self._halved(_x) / Int(4))

    def _test(self):
        return Int(1)

def _sum():
    return Int(0)

if __name__ == '__main__':
    # clear screen before executing
    import platform
    import os
    os.system('cls' if platform.system() == 'Windows' else 'clear')

    # declare globals
    main()
```