### PR TITLE
Fix/escaped char transpilation

### DIFF
--- a/src/compiler/compiler.py
+++ b/src/compiler/compiler.py
@@ -9,7 +9,7 @@ class Compiler:
     def __init__(self, py_source: str, filename: str) -> None:
         if not (res := self.validate_file(filename)): return
         self.filename = res
-        self.source = self.builtins() + py_source.replace('\\\\', '\\')
+        self.source = self.builtins() + py_source
 
     def validate_file(self, filename: str) -> str|None:
         # TODO: add more validations maybe?

--- a/src/lexer/lexer_components/peek.py
+++ b/src/lexer/lexer_components/peek.py
@@ -361,7 +361,7 @@ def string(context: tuple[list[str], list[int], str, list[Token], list[DelimErro
                 _, current_char = reverse_cursor(context)
                 context = lines, position, current_char, tokens, logs
 
-            starting_position = (position[0], position[1]-len(temp_string)+1)
+            starting_position = (position[0], position[1]-len(temp_string.replace('\\\\', '\\'))+1)
             ending_position = (position[0], position[1])
             logs.append(GenericError(Error.UNCLOSED_STRING, starting_position, ending_position,
                                             context = f"'{temp_string}' is unclosed"))
@@ -390,7 +390,7 @@ def string(context: tuple[list[str], list[int], str, list[Token], list[DelimErro
 
             temp_string += current_char
             temp_string = '"' + temp_string[1:-1] + '"'
-            temp_string_length = len(temp_string) + escape_count
+            temp_string_length = len(temp_string.replace('\\\\', '\\'))
 
             starting_position = (position[0], position[1]-temp_string_length+1)
             ending_position = (position[0], position[1])

--- a/src/lexer/lexer_components/peek.py
+++ b/src/lexer/lexer_components/peek.py
@@ -374,11 +374,8 @@ def string(context: tuple[list[str], list[int], str, list[Token], list[DelimErro
             if is_end_of_file:
                 break
 
-            # NOTE put escapable characters here
-            if current_char not in ["|", '"']:
-                _, current_char = reverse_cursor(context)
-                context = lines, position, current_char, tokens, logs
-            temp_string += '\\'
+            if current_char == '|': temp_string += ''
+            else: temp_string += '\\'
         
         elif current_char in ['|', '"']:
             if current_char == '|':

--- a/src/lexer/lexer_components/peek.py
+++ b/src/lexer/lexer_components/peek.py
@@ -361,7 +361,7 @@ def string(context: tuple[list[str], list[int], str, list[Token], list[DelimErro
                 _, current_char = reverse_cursor(context)
                 context = lines, position, current_char, tokens, logs
 
-            starting_position = (position[0], position[1]-len(temp_string.replace('\\\\', '\\'))+1)
+            starting_position = (position[0], position[1]-len(temp_string) + 1 + temp_string.count('|'))
             ending_position = (position[0], position[1])
             logs.append(GenericError(Error.UNCLOSED_STRING, starting_position, ending_position,
                                             context = f"'{temp_string}' is unclosed"))
@@ -387,7 +387,7 @@ def string(context: tuple[list[str], list[int], str, list[Token], list[DelimErro
 
             temp_string += current_char
             temp_string = '"' + temp_string[1:-1] + '"'
-            temp_string_length = len(temp_string.replace('\\\\', '\\'))
+            temp_string_length = len(temp_string) + temp_string.count('|')
 
             starting_position = (position[0], position[1]-temp_string_length+1)
             ending_position = (position[0], position[1])

--- a/src/lexer/lexer_components/peek.py
+++ b/src/lexer/lexer_components/peek.py
@@ -347,7 +347,6 @@ def string(context: tuple[list[str], list[int], str, list[Token], list[DelimErro
         token_types = (TokenType.STRING_PART_MID, TokenType.STRING_PART_END)
     
     temp_string = ''
-    escape_count = 0
     current_line = position[0]
 
     while True:
@@ -379,10 +378,7 @@ def string(context: tuple[list[str], list[int], str, list[Token], list[DelimErro
             if current_char not in ["|", '"']:
                 _, current_char = reverse_cursor(context)
                 context = lines, position, current_char, tokens, logs
-
-                temp_string += '\\'
-            else:
-                escape_count += 1
+            temp_string += '\\'
         
         elif current_char in ['|', '"']:
             if current_char == '|':

--- a/src/lexer/token.py
+++ b/src/lexer/token.py
@@ -370,7 +370,7 @@ class Token:
             case TokenType.FLOAT_LITERAL:
                 return f"Float({self.lexeme})"
             case TokenType.STRING_LITERAL:
-                return f"String({self.lexeme})"
+                return f"String({self.lexeme.replace('{', '{{').replace('}', '}}')})"
             case TokenType.MAINUWU:
                 return "main"
             case TokenType.FWUNC:
@@ -415,11 +415,11 @@ class Token:
             case TokenType.NUWW:
                 return "None"
             case TokenType.STRING_PART_START:
-                return f'String(f{self.lexeme[:-1]}{{'
+                return f"String(f{self.lexeme[:-1].replace('{', '{{').replace('}', '}}')}{{"
             case TokenType.STRING_PART_MID:
-                return f'}}{self.lexeme[1:-1]}{{'
+                return f"}}{self.lexeme[1:-1].replace('{', '{{').replace('}', '}}')}{{"
             case TokenType.STRING_PART_END:
-                return f'}}{self.lexeme[1:]})'
+                return f"}}{self.lexeme[1:].replace('{', '{{').replace('}', '}}')})"
             case TokenType.FAX:
                 return "Bool(True)"
             case TokenType.CAP:
@@ -512,7 +512,7 @@ class Token:
 
     @property
     def lexeme(self) -> str:
-        return self._lexeme.replace("\\\\", "\\")
+        return self._lexeme
 
     @lexeme.setter
     def lexeme(self, lexeme: str):


### PR DESCRIPTION
# escaped char transpilation is simpler now
- `\`, `"`, `n`, `t`, `r`, `b`, and `f` are not escaped in lexer. python will handle the escaping in execution
- `|` however is escaped in lexer

```
"\\\"\n\t\r\b\f" --> "\\\"\n\t\r\b\f" (python will handle escaping this during execution)
"\|" --> | (we escape this in lexer)
```

---
## test log
### source
```python
sample text file
-----------------------------------------------------------------------------------
1 |
2 | fwunc mainuwu-san() [[
3 |     a-chan = 1~
4 |     pwint("abs {\\\"one\\\"}:<newline>\n<tab>\t \|| a|\|")~
5 |     pwint("\n")~
6 |     pwint("abs \\\"one\\\":<newline>\n<tab>\t<back>\b<return>\r<feed>\f\|\|")~
7 | ]]
8 |
9 |
10 |
-----------------------------------------------------------------------------------
end of file
```
### transpiled
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/01a859cd-df19-4394-a475-8a36d45f6a33)

### output
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/a0791097-0abd-415a-9a39-47a88db3937a)
