### PR TITLE
Comment Parsing in Class Bodies

### DIFF
--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -549,7 +549,11 @@ class Parser:
                 else:
                     c.definition_order.append([res])
 
-                self.advance()
+                self.advance(skip_comments=False)
+            elif self.curr_tok_is_in([TokenType.SINGLE_LINE_COMMENT, TokenType.MULTI_LINE_COMMENT]):
+                res = Comment(self.curr_tok)
+                c.definition_order.append(res)
+                self.advance(skip_comments=False)
             else:
                 self.expected_error([TokenType.FWUNC, "IDENTIFIER"], curr=True)
                 self.advance()


### PR DESCRIPTION
Fixes:
- comments after attribute declarations get deleted on format
- comments after method declarations don't get parsed correctly

Preview:
Src Code
![image](https://github.com/Gidsss/UwUIDE/assets/66175571/a1ecb755-6021-46ba-98e3-56fe7e9b28bb)

On Format
![image](https://github.com/Gidsss/UwUIDE/assets/66175571/0025d2c0-62f2-4c51-bd43-d4215e8fe00e)

On Compile
![image](https://github.com/Gidsss/UwUIDE/assets/66175571/bf76c0e7-a697-44a9-9a32-2a774fbcbc14)
