### PR TITLE
Fix/syntax highlight string mid

### DIFF
--- a/src/components/analyzer_tabs.py
+++ b/src/components/analyzer_tabs.py
@@ -94,7 +94,8 @@ class UwUParserTab(CTkScrollableFrame):
 
     def clear_highlight(self, event):
         self.code_editor = Remote.code_editor_instance
-        self.code_editor.clear_format()
+        if(self.code_editor):
+            self.code_editor.clear_format()
 
 class UwULexerTab(CTkScrollableFrame):
     def __init__(self, master, **kwargs):

--- a/theme/config.py
+++ b/theme/config.py
@@ -108,6 +108,7 @@ class ThemeConfig():
         'FLOAT_LITERAL' : self.theme_colors.NUMBER,
         'STRING_LITERAL' : self.theme_colors.STRING,
         'STRING_PART_START' : self.theme_colors.STRING,
+        'STRING_PART_MID' : self.theme_colors.STRING,
         'STRING_PART_END' : self.theme_colors.STRING,
         'fax' : self.theme_colors.BOOL,
         'cap' : self.theme_colors.BOOL,


### PR DESCRIPTION
## Description
This PR fixes unhighlighted `string_part_mid` in syntax highlighting. Also fixed hovering issue in Parser tab.

closes #322 
## Preview
![image](https://github.com/Gidsss/UwUIDE/assets/70326902/0a6fbcd0-4781-4194-b22b-3d803d882fc3)
