### PR TITLE
Fix/string indexing and accessor bugs

### DIFF
--- a/src/analyzer/type_checker.py
+++ b/src/analyzer/type_checker.py
@@ -737,7 +737,7 @@ class TypeChecker:
             case IndexedIdentifier():
                 try: definition, class_type, global_type = self.class_signatures[f"{parent_type}.{id}"].items()
                 except: definition, class_type, global_type = local_defs[id].items()
-                if class_type.dimension() < len(accessor.id.index):
+                if class_type.dimension() < len(accessor.id.index) and not class_type.type_is_in([TokenType.SENPAI, TokenType.SENPAI_ARR]):
                     token = self.extract_id(accessor.id)
                     type_definition = local_defs[token.flat_string()].decl.dtype
                     self.errors.append(

--- a/src/builtin/types/iterable.py
+++ b/src/builtin/types/iterable.py
@@ -54,7 +54,7 @@ class String:
 
     # subscripting
     def __getitem__(self, index):
-        return self.val[index]
+        return String(self.val[index])
     def __contains__(self, item):
         return item in self.val
     def __iter__(self):


### PR DESCRIPTION
fixes point 2 in #321 

> - [ ] Indexed strings break when accessing its built-in methods @am-cid 
> ![image](https://github.com/Gidsss/UwUIDE/assets/66175571/f74aa866-6df3-4a13-99d6-8fa903ef2f91)

---

## changes
- strings now can be indexed into infinitely (if not empty)
  - eg. `str{0}{0}{0}{0}{0}...`
- string indexing (`str{0}`) now returns `String` instead of `str`

---
## test log
### source
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/3775c057-b7e6-40b1-bc75-a81b35000cdc)
### transpiled
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/7b67f5cd-3c80-4233-af24-d852f4bdd3a3)
### output
![image](https://github.com/Gidsss/UwUIDE/assets/146176671/1cfa6b57-9520-4c15-9c47-487cb6ba1836)
